### PR TITLE
Drop leading dot for renderFullname when namespace is null

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  haskell: haskell-works/haskell-build@1.4.1
+  haskell: haskell-works/haskell-build@1.6.3
   github: haskell-works/github-release@1.2.1
   hackage: haskell-works/hackage@1.0.0
 

--- a/avro.cabal
+++ b/avro.cabal
@@ -27,6 +27,7 @@ extra-source-files:
     test/data/unions.avsc
     test/data/enums-object.json
     test/data/namespace-inference.json
+    test/data/null-namespace.json
     test/data/unions-object-a.json
     test/data/unions-object-b.json
     test/data/deconflict/reader.avsc

--- a/avro.cabal
+++ b/avro.cabal
@@ -1,7 +1,7 @@
-cabal-version: >=1.12
+cabal-version: 1.12
 
 name:           avro
-version:        0.4.2.0
+version:        0.4.3.0
 synopsis:       Avro serialization support for Haskell
 description:    Avro serialization and deserialization support for Haskell
 category:       Data

--- a/src/Data/Avro/Schema.hs
+++ b/src/Data/Avro/Schema.hs
@@ -267,7 +267,7 @@ mkTypeName :: Maybe TypeName
 mkTypeName context name ns
   | isFullName name = parseFullname name
   | otherwise       = case ns of
-      Just ns -> TN name $ T.splitOn "." ns
+      Just ns -> TN name $ filter (/= "") (T.splitOn "." ns)
       Nothing -> TN name $ fromMaybe [] $ namespace <$> context
   where isFullName = isJust . T.find (== '.')
 

--- a/src/Data/Avro/Schema.hs
+++ b/src/Data/Avro/Schema.hs
@@ -221,7 +221,7 @@ instance Show TypeName where
 -- @
 renderFullname :: TypeName -> T.Text
 renderFullname TN { baseName, namespace } =
-  T.intercalate "." namespace <> "." <> baseName
+  T.intercalate "." $ namespace ++ [baseName]
 
 -- | Parses a fullname into a 'TypeName', assuming the string
 -- representation is valid.

--- a/test/Avro/NamespaceSpec.hs
+++ b/test/Avro/NamespaceSpec.hs
@@ -28,6 +28,11 @@ spec = describe "NamespaceSpec.hs: namespace inference in Avro schemas" $ do
     let expectedJSONSchema :: Aeson.Value
         Just expectedJSONSchema = head <$> Aeson.decode schemas
     Aeson.toJSON expected `shouldBe` expectedJSONSchema
+  it "should render names in the null namespace with no leading '.'" $
+    renderFullname (TN "FooType" []) `shouldBe` "FooType"
+  nullNamespaceSchema <- runIO $ getFileName "test/data/null-namespace.json" >>= LBS.readFile
+  it "should generate JSON with null namespaces rendered correctly" $
+    Aeson.decode nullNamespaceSchema `shouldBe` Just expectedNullNamespace
 
 expected :: Schema
 expected = Record
@@ -58,6 +63,18 @@ expected = Record
                       , field "bazzy" $ NamedType "com.example.Bazzy"
                       ]
           }
+
+
+expectedNullNamespace :: Schema
+expectedNullNamespace = Record
+  { name    = "Foo"
+  , aliases = []
+  , doc     = Just "An example schema to test null namespace handling."
+  , order   = Just Ascending
+  , fields  = [field "bar" $ NamedType "Bar", field "baz" $ NamedType "com.example.Baz"]
+  }
+  where field name schema = Field name [] Nothing (Just Ascending) schema Nothing
+
 
 getFileName :: FilePath -> IO FilePath
 getFileName p = do

--- a/test/data/null-namespace.json
+++ b/test/data/null-namespace.json
@@ -1,0 +1,17 @@
+{
+  "type" : "record",
+  "name" : "Foo",
+  "namespace" : "",
+  "aliases" : [],
+  "doc": "An example schema to test null namespace handling.",
+  "fields" : [
+    {
+      "name" : "bar",
+      "type" : "Bar"
+    },
+    {
+      "name" : "baz",
+      "type" : "com.example.Baz"
+    }
+  ]
+}


### PR DESCRIPTION
After this change:
```
*Data.Avro> renderFullname $ TN "Hi" []
"Hi"
*Data.Avro> renderFullname $ TN "Hi" ["foo"]
"foo.Hi"
*Data.Avro> renderFullname $ TN "Hi" ["foo", "org"]
"foo.org.Hi"
```

The python bindings fail to parse ".Hi", so we should produce compatible avro json, while we continue parsing both styles (leading-dot and no-leading-dot).

Well, I'm not sure that we _should_, but it is a lot more convenient if we do :)