### PR TITLE
Fixed parsing unions with arrays and maps in JSON.

### DIFF
--- a/src/Data/Avro/JSON.hs
+++ b/src/Data/Avro/JSON.hs
@@ -97,7 +97,7 @@ decodeAvroJSON schema json =
       | otherwise      =
           let
             canonicalize name
-              | Just _ <- Schema.primitiveType name = name
+              | Schema.isPrimitiveType name = name
               | otherwise = Schema.renderFullname $ Schema.parseFullname name
             branch =
               head $ HashMap.keys obj

--- a/src/Data/Avro/Schema.hs
+++ b/src/Data/Avro/Schema.hs
@@ -27,7 +27,7 @@ module Data.Avro.Schema
   , validateSchema
   -- * Lower level utilities
   , typeName
-  , primitiveType
+  , isPrimitiveType
   , buildTypeEnvironment
   , extractBindings
 
@@ -296,26 +296,29 @@ typeName bt =
     Union (x:|_) _ -> typeName x
     _              -> renderFullname $ name bt
 
--- | If the given string is the name of a primitive type, return the
--- type, otherwise return 'Nothing'.
+-- | Returns whether the given 'Text' is the name of a primitive type.
 --
 -- @
--- λ> primitiveType "string"
--- Just String
--- λ> primitiveType "foo"
--- Nothing
+-- λ> isPrimitiveType "string"
+-- True
+-- λ> isPrimitiveType "array"
+-- True
+-- λ> isPrimitiveType "foo"
+-- False
 -- @
-primitiveType :: Text -> Maybe Type
-primitiveType = \case
-  "null"    -> Just Null
-  "boolean" -> Just Boolean
-  "int"     -> Just Int
-  "long"    -> Just Long
-  "float"   -> Just Float
-  "double"  -> Just Double
-  "bytes"   -> Just Bytes
-  "string"  -> Just String
-  _         -> Nothing
+isPrimitiveType :: Text -> Bool
+isPrimitiveType = (`elem` names)
+  where names = [ "null"
+                , "boolean"
+                , "int"
+                , "long"
+                , "float"
+                , "double"
+                , "bytes"
+                , "string"
+                , "array"
+                , "map"
+                ]
 
 data Field = Field { fldName    :: Text
                    , fldAliases :: [Text]

--- a/test/Avro/JSONSpec.hs
+++ b/test/Avro/JSONSpec.hs
@@ -8,6 +8,7 @@ import           Control.Monad        (forM_)
 
 import qualified Data.Aeson           as Aeson
 import qualified Data.ByteString.Lazy as LBS
+import qualified Data.Map             as Map
 
 import           Data.Avro.Deriving
 import           Data.Avro.EitherN
@@ -69,24 +70,26 @@ spec = describe "Avro.JSONSpec: JSON serialization/parsing" $ do
     let expected = EnumWrapper 37 "blarg" EnumReasonInstead
     parseJSON enumsExampleJSON `shouldBe` pure expected
   let unionsExampleA = Unions
-        { unionsScalars    = Left "blarg"
-        , unionsNullable   = Nothing
-        , unionsRecords    = Left $ Foo { fooStuff = "stuff" }
-        , unionsSameFields = Left $ Foo { fooStuff = "foo stuff" }
-        , unionsThree      = E3_1 37
-        , unionsFour       = E4_2 "foo"
-        , unionsFive       = E5_4 $ Foo { fooStuff = "foo stuff" }
+        { unionsScalars     = Left "blarg"
+        , unionsNullable    = Nothing
+        , unionsRecords     = Left $ Foo { fooStuff = "stuff" }
+        , unionsSameFields  = Left $ Foo { fooStuff = "foo stuff" }
+        , unionsArrayAndMap = Left ["foo"]
+        , unionsThree       = E3_1 37
+        , unionsFour        = E4_2 "foo"
+        , unionsFive        = E5_4 $ Foo { fooStuff = "foo stuff" }
         }
       unionsExampleB = Unions
-        { unionsScalars    = Right 37
-        , unionsNullable   = Just 42
-        , unionsRecords    = Right $ Bar { barStuff = "stuff"
-                                      , barThings = Foo "things"
-                                      }
-        , unionsSameFields = Right $ NotFoo { notFooStuff = "not foo stuff" }
-        , unionsThree      = E3_3 37
-        , unionsFour       = E4_4 $ Foo { fooStuff = "foo stuff" }
-        , unionsFive       = E5_5 $ NotFoo { notFooStuff = "not foo stuff" }
+        { unionsScalars     = Right 37
+        , unionsNullable    = Just 42
+        , unionsRecords     = Right $ Bar { barStuff = "stuff"
+                                          , barThings = Foo "things"
+                                          }
+        , unionsSameFields  = Right $ NotFoo { notFooStuff = "not foo stuff" }
+        , unionsArrayAndMap = Right $ Map.fromList [("a", 5)]
+        , unionsThree       = E3_3 37
+        , unionsFour        = E4_4 $ Foo { fooStuff = "foo stuff" }
+        , unionsFive        = E5_5 $ NotFoo { notFooStuff = "not foo stuff" }
         }
   it "should roundtrip (unions)" $ do
     forM_ [unionsExampleA, unionsExampleB] $ \ msg ->

--- a/test/Avro/THUnionSpec.hs
+++ b/test/Avro/THUnionSpec.hs
@@ -14,6 +14,7 @@ import           Data.Avro.EitherN
 import qualified Data.Avro.Schema     as Schema
 import qualified Data.Avro.Types      as Avro
 import qualified Data.ByteString.Lazy as LBS
+import qualified Data.Map             as Map
 
 import           System.Directory     (doesFileExist)
 
@@ -26,24 +27,26 @@ deriveAvro "test/data/unions.avsc"
 spec :: Spec
 spec = describe "Avro.THUnionSpec: Schema with unions." $ do
   let objA = Unions
-        { unionsScalars    = Left "foo"
-        , unionsNullable   = Nothing
-        , unionsRecords    = Left $ Foo { fooStuff = "stuff" }
-        , unionsSameFields = Left $ Foo { fooStuff = "more stuff" }
-        , unionsThree      = E3_1 37
-        , unionsFour       = E4_2 "foo"
-        , unionsFive       = E5_4 $ Foo { fooStuff = "foo stuff" }
+        { unionsScalars     = Left "foo"
+        , unionsNullable    = Nothing
+        , unionsRecords     = Left $ Foo { fooStuff = "stuff" }
+        , unionsSameFields  = Left $ Foo { fooStuff = "more stuff" }
+        , unionsArrayAndMap = Left ["foo"]
+        , unionsThree       = E3_1 37
+        , unionsFour        = E4_2 "foo"
+        , unionsFive        = E5_4 $ Foo { fooStuff = "foo stuff" }
         }
       objB = Unions
-        { unionsScalars    = Right 42
-        , unionsNullable   = Just 37
-        , unionsRecords    = Right $ Bar { barStuff  = "stuff"
-                                         , barThings = Foo { fooStuff = "things" }
-                                       }
-        , unionsSameFields = Right $ NotFoo { notFooStuff = "different from Foo" }
-        , unionsThree      = E3_3 37
-        , unionsFour       = E4_4 $ Foo { fooStuff = "foo stuff" }
-        , unionsFive       = E5_5 $ NotFoo { notFooStuff = "not foo stuff" }
+        { unionsScalars     = Right 42
+        , unionsNullable    = Just 37
+        , unionsRecords     = Right $ Bar { barStuff  = "stuff"
+                                          , barThings = Foo { fooStuff = "things" }
+                                          }
+        , unionsSameFields  = Right $ NotFoo { notFooStuff = "different from Foo" }
+        , unionsArrayAndMap = Right $ Map.fromList [("a", 5)]
+        , unionsThree       = E3_3 37
+        , unionsFour        = E4_4 $ Foo { fooStuff = "foo stuff" }
+        , unionsFive        = E5_5 $ NotFoo { notFooStuff = "not foo stuff" }
         }
 
       field name schema def = Schema.Field name [] Nothing (Just Schema.Ascending) schema def
@@ -54,10 +57,11 @@ spec = describe "Avro.THUnionSpec: Schema with unions." $ do
       foo    = named "haskell.avro.example.Foo"
       notFoo = named "haskell.avro.example.NotFoo"
       expectedSchema = record "haskell.avro.example.Unions"
-        [ field "scalars"    (Schema.mkUnion (NE.fromList [Schema.String, Schema.Long])) scalarsDefault
-        , field "nullable"   (Schema.mkUnion (NE.fromList [Schema.Null, Schema.Int]))    nullableDefault
-        , field "records"    (Schema.mkUnion (NE.fromList [fooSchema, barSchema]))       Nothing
-        , field "sameFields" (Schema.mkUnion (NE.fromList [foo, notFooSchema]))          Nothing
+        [ field "scalars"     (Schema.mkUnion (NE.fromList [Schema.String, Schema.Long])) scalarsDefault
+        , field "nullable"    (Schema.mkUnion (NE.fromList [Schema.Null, Schema.Int]))    nullableDefault
+        , field "records"     (Schema.mkUnion (NE.fromList [fooSchema, barSchema]))       Nothing
+        , field "sameFields"  (Schema.mkUnion (NE.fromList [foo, notFooSchema]))          Nothing
+        , field "arrayAndMap" (Schema.mkUnion (NE.fromList [array, map]))                 Nothing
 
         , field "three" (Schema.mkUnion (NE.fromList [Schema.Int, Schema.String, Schema.Long]))              Nothing
         , field "four"  (Schema.mkUnion (NE.fromList [Schema.Int, Schema.String, Schema.Long, foo]))         Nothing
@@ -72,6 +76,9 @@ spec = describe "Avro.THUnionSpec: Schema with unions." $ do
         , field "things" (named "haskell.avro.example.Foo") Nothing
         ]
       notFooSchema = record "haskell.avro.example.NotFoo" [field "stuff" Schema.String Nothing]
+
+      array = Schema.Array { Schema.item = Schema.String }
+      map   = Schema.Map { Schema.values = Schema.Long }
 
   unionsSchemaFile <- runIO $ getFileName "test/data/unions.avsc" >>= LBS.readFile
   let Just unionsSchemaFromJSON = Aeson.decode unionsSchemaFile

--- a/test/data/unions-object-a.json
+++ b/test/data/unions-object-a.json
@@ -13,6 +13,9 @@
       "stuff": "foo stuff"
     }
   },
+  "arrayAndMap" : {
+    "array" : ["foo"]
+  },
   "three": { "int": 37 },
   "four": { "string": "foo" },
   "five": {

--- a/test/data/unions-object-b.json
+++ b/test/data/unions-object-b.json
@@ -18,6 +18,9 @@
       "stuff": "not foo stuff"
     }
   },
+  "arrayAndMap" : {
+    "map" : { "a" : 5 }
+  },
   "three": { "long": 37 },
   "four": {
     "haskell.avro.example.Foo": { "stuff" : "foo stuff" }

--- a/test/data/unions.avsc
+++ b/test/data/unions.avsc
@@ -44,6 +44,16 @@
         }
       ]
     },
+    { "name" : "arrayAndMap",
+      "type" : [
+        { "type" : "array",
+          "items" : "string"
+        },
+        { "type" : "map",
+          "values" : "long"
+        }
+      ]
+    },
     { "name" : "three", "type" : ["int", "string", "long"] },
     { "name" : "four", "type" : ["int", "string", "long", "Foo"] },
     { "name" : "five", "type" : ["int", "string", "long", "Foo", "NotFoo"] }


### PR DESCRIPTION
An Avro union can contain up to one array and one map type as options. In JSON, a value of a union that is an array is represented as follows:

```
{ "array" : [1,2,3] }
```

and maps are

```
{ "map" : { "a" : 1, "b" : 2 } }
```

Currently, trying to parse an object like this with an appropriate schema gives us the following error:

```
Error "Type 'array' not in union: Array {item = String} :| [Map {values = Long}]"
```

After this PR, these objects will be parsed correctly according to the schema.