### PR TITLE
Implemented a benchmark suite, with some benchmarks encoding/decoding arrays.

### DIFF
--- a/avro.cabal
+++ b/avro.cabal
@@ -92,6 +92,7 @@ library
     , bytestring
     , containers
     , data-binary-ieee754
+    , deepseq
     , fail
     , hashable
     , mtl
@@ -186,3 +187,25 @@ test-suite test
   if flag(dev)
     ghc-options: -Wall -Werror
   default-language: Haskell2010
+
+benchmark bench-time
+  type: exitcode-stdio-1.0
+  main-is: Time.hs
+  hs-source-dirs: bench
+  build-depends:
+      avro
+    , base >=4.6 && <5
+
+    , aeson
+    , bytestring
+    , containers
+    , hashable
+    , mtl
+    , text
+    , random
+    , transformers
+    , unordered-containers
+    , vector
+
+    -- benchmarking-specific libraries
+    , gauge

--- a/bench/Time.hs
+++ b/bench/Time.hs
@@ -1,0 +1,121 @@
+{-# LANGUAGE NumDecimals         #-}
+{-# LANGUAGE OverloadedLists     #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+module Main where
+
+import           Control.Monad         (replicateM)
+
+import qualified Data.ByteString.Lazy  as LBS
+import           Data.HashMap.Strict   (HashMap)
+import qualified Data.HashMap.Strict   as HashMap
+import           Data.Text             (Text)
+import           Data.Vector           (Vector)
+import qualified Data.Vector           as Vector
+
+import           Gauge
+
+import           GHC.Int               (Int32, Int64)
+
+import qualified System.Random         as Random
+
+import qualified Data.Avro             as Avro
+import qualified Data.Avro.Decode      as Decode
+import qualified Data.Avro.Encode      as Encode
+import           Data.Avro.Schema      (Schema)
+import qualified Data.Avro.Schema      as Schema
+import           Data.Avro.Types.Value (Value)
+import qualified Data.Avro.Types.Value as Value
+
+main :: IO ()
+main = defaultMain [encode, decode]
+
+-- * Encoding to binary
+
+encode :: Benchmark
+encode = bgroup "encode" [ encodeArray ]
+
+encodeArray :: Benchmark
+encodeArray = env randoms $ \ ~(bools, ints, longs, records) ->
+  bgroup "array"
+  [ bench "bools" $
+      nf encodeAvro $ Value.Array $ Value.Boolean <$> bools
+  , bench "ints" $
+      nf encodeAvro $ Value.Array $ Value.Int <$> ints
+  , bench "longs" $
+      nf encodeAvro $ Value.Array $ Value.Long <$> longs
+  , bench "records" $
+      nf encodeAvro $ Value.Array records
+  ]
+  where randoms = do
+          bools <- array
+          ints  <- array
+          longs <- array
+          pure (bools, ints, longs, records bools ints longs)
+
+        array :: (Bounded r, Random.Random r) => IO (Vector r)
+        array = Vector.replicateM 1e5 (Random.randomRIO (minBound, maxBound))
+
+        records bools ints longs =
+          Vector.zipWith3 record bools ints longs
+        record bool int long = Value.Record recordSchema
+          [ ("b", Value.Boolean bool)
+          , ("i", Value.Int int)
+          , ("l", Value.Long long)
+          ]
+        recordSchema = Schema.Record "Rec" [] Nothing Nothing
+          [ Schema.Field "b" [] Nothing Nothing Schema.Boolean Nothing
+          , Schema.Field "i" [] Nothing Nothing Schema.Int Nothing
+          , Schema.Field "l" [] Nothing Nothing Schema.Long Nothing
+          ]
+
+encodeAvro :: Value Schema -> LBS.ByteString
+encodeAvro = Encode.encodeAvro
+
+-- * Decoding from binary
+
+decode :: Benchmark
+decode = bgroup "decode" [ decodeArray ]
+
+decodeArray :: Benchmark
+decodeArray = env randoms $ \ ~(bools, ints, longs, records) ->
+  bgroup "array"
+  [ bench "bools" $
+      nf (decodeAvro $ Schema.Array Schema.Boolean) bools
+  , bench "ints" $
+      nf (decodeAvro $ Schema.Array Schema.Int) ints
+  , bench "longs" $
+      nf (decodeAvro $ Schema.Array Schema.Long) longs
+  , bench "records" $
+      nf (decodeAvro $ Schema.Array recordSchema) records
+  ]
+  where randoms = do
+          bools <- array
+          ints  <- array
+          longs <- array
+          pure ( encodeAvro $ Value.Array $ Value.Boolean <$> bools
+               , encodeAvro $ Value.Array $ Value.Int <$> ints
+               , encodeAvro $ Value.Array $ Value.Long <$> longs
+               , encodeAvro $ Value.Array $ records bools ints longs
+               )
+
+        array :: (Bounded r, Random.Random r) => IO (Vector r)
+        array = Vector.replicateM 1e5 (Random.randomRIO (minBound, maxBound))
+
+        records bools ints longs =
+          Vector.zipWith3 record bools ints longs
+        record bool int long = Value.Record recordSchema
+          [ ("b", Value.Boolean bool)
+          , ("i", Value.Int int)
+          , ("l", Value.Long long)
+          ]
+        recordSchema = Schema.Record "Rec" [] Nothing Nothing
+          [ Schema.Field "b" [] Nothing Nothing Schema.Boolean Nothing
+          , Schema.Field "i" [] Nothing Nothing Schema.Int Nothing
+          , Schema.Field "l" [] Nothing Nothing Schema.Long Nothing
+          ]
+
+decodeAvro :: Schema -> LBS.ByteString -> Value Schema
+decodeAvro schema bytes = case Decode.decodeAvro schema bytes of
+  Left err  -> error err
+  Right res -> res

--- a/src/Data/Avro/Schema.hs
+++ b/src/Data/Avro/Schema.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DeriveAnyClass        #-}
+{-# LANGUAGE DeriveGeneric         #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -46,37 +48,41 @@ module Data.Avro.Schema
   ) where
 
 import           Control.Applicative
+import           Control.DeepSeq            (NFData)
 import           Control.Monad.Except
 import qualified Control.Monad.Fail         as MF
 import           Control.Monad.State.Strict
 
-import           Data.Aeson             (FromJSON (..), ToJSON (..), object, (.!=), (.:), (.:!), (.:?), (.=))
-import qualified Data.Aeson             as A
-import           Data.Aeson.Types       (Parser, typeMismatch)
-import qualified Data.Avro.Types        as Ty
-import qualified Data.ByteString        as B
-import qualified Data.ByteString.Base16 as Base16
-import qualified Data.Char              as Char
-import           Data.Function          (on)
+import           Data.Aeson                 (FromJSON (..), ToJSON (..), object,
+                                             (.!=), (.:), (.:!), (.:?), (.=))
+import qualified Data.Aeson                 as A
+import           Data.Aeson.Types           (Parser, typeMismatch)
+import qualified Data.Avro.Types            as Ty
+import qualified Data.ByteString            as B
+import qualified Data.ByteString.Base16     as Base16
+import qualified Data.Char                  as Char
+import           Data.Function              (on)
 import           Data.Hashable
-import qualified Data.HashMap.Strict    as HashMap
+import qualified Data.HashMap.Strict        as HashMap
 import           Data.Int
-import qualified Data.IntMap            as IM
-import qualified Data.List              as L
-import           Data.List.NonEmpty     (NonEmpty (..))
-import qualified Data.List.NonEmpty     as NE
-import           Data.Maybe             (catMaybes, fromMaybe, isJust)
-import           Data.Monoid            (First (..))
+import qualified Data.IntMap                as IM
+import qualified Data.List                  as L
+import           Data.List.NonEmpty         (NonEmpty (..))
+import qualified Data.List.NonEmpty         as NE
+import           Data.Maybe                 (catMaybes, fromMaybe, isJust)
+import           Data.Monoid                (First (..))
 import           Data.Semigroup
-import qualified Data.Set               as S
+import qualified Data.Set                   as S
 import           Data.String
-import           Data.Text              (Text)
-import qualified Data.Text              as T
-import           Data.Text.Encoding     as T
-import qualified Data.Vector            as V
-import           Prelude                as P
+import           Data.Text                  (Text)
+import qualified Data.Text                  as T
+import           Data.Text.Encoding         as T
+import qualified Data.Vector                as V
+import           Prelude                    as P
 
-import Text.Show.Functions ()
+import           GHC.Generics               (Generic)
+
+import           Text.Show.Functions        ()
 
 -- |An Avro schema is either
 -- * A "JSON object in the form `{"type":"typeName" ...`
@@ -121,7 +127,7 @@ data Type
               , aliases :: [TypeName]
               , size    :: Int
               }
-    deriving (Show)
+    deriving (Show, Generic, NFData)
 
 instance Eq Type where
   Null == Null = True
@@ -195,7 +201,7 @@ mkUnion os = Union os (\i -> IM.lookup (fromIntegral i) mp)
 data TypeName = TN { baseName  :: T.Text
                    , namespace :: [T.Text]
                    }
-  deriving (Eq, Ord)
+  deriving (Eq, Ord, Generic, NFData)
 
 -- | Show the 'TypeName' as a string literal compatible with its
 -- 'IsString' instance.
@@ -302,10 +308,10 @@ data Field = Field { fldName    :: Text
                    , fldType    :: Type
                    , fldDefault :: Maybe (Ty.Value Type)
                    }
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic, NFData)
 
 data Order = Ascending | Descending | Ignore
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic, NFData)
 
 instance FromJSON Type where
   parseJSON = parseSchemaJSON Nothing

--- a/src/Data/Avro/Types/Value.hs
+++ b/src/Data/Avro/Types/Value.hs
@@ -1,4 +1,8 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric  #-}
 module Data.Avro.Types.Value where
+
+import           Control.DeepSeq     (NFData)
 
 import           Data.ByteString
 import           Data.HashMap.Strict (HashMap)
@@ -6,6 +10,8 @@ import           Data.Int
 import           Data.List.NonEmpty  (NonEmpty)
 import           Data.Text
 import           Data.Vector
+
+import           GHC.Generics        (Generic)
 
 data Value f
       = Null
@@ -22,4 +28,4 @@ data Value f
       | Union (NonEmpty f) f (Value f) -- ^ Set of union options, schema for selected option, and the actual value.
       | Fixed f {-# UNPACK #-} !ByteString
       | Enum f {-# UNPACK #-} !Int Text  -- ^ An enum is a set of the possible symbols (the schema) and the selected symbol
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic, NFData)


### PR DESCRIPTION
The initial benchmark suite measures encoding and decoding four kinds of arrays:

  * 10,000 booleans
  * 10,000 ints
  * 10,000 longs
  * 10,000 records with the booleans, ints and longs as fields

This by itself gives us an interesting result: encoding/decoding a record takes ~2x as much time as encoding/decoding separate arrays with exactly the same data.

```
encode/array/bools                       mean 4.955 ms  ( +- 66.76 μs  )
encode/array/ints                        mean 5.366 ms  ( +- 59.39 μs  )
encode/array/longs                       mean 6.291 ms  ( +- 86.93 μs  )
encode/array/records                     mean 35.84 ms  ( +- 333.0 μs  )

decode/array/bools                       mean 20.50 ms  ( +- 230.4 μs  )
decode/array/ints                        mean 64.30 ms  ( +- 3.144 ms  )
decode/array/longs                       mean 110.8 ms  ( +- 3.757 ms  )
decode/array/records                     mean 301.7 ms  ( +- 8.999 ms  )
```

You can run the benchmarks with this shorter output using the following command:

```
cabal new-run bench-time -- -s
```

I *think* I implemented these benchmarks correctly, but it would be great for somebody else to take a look and make sure that I'm actually measuring what I want to measure and things like the setup costs for the benchmark don't get measured.

This is just a starting point—it would be great to have more benchmarks.

We should also start benchmarking against the TH-generated types directly. Currently the TH instances go through the intermediate `Value` type, but I've found that this approach is *really* inefficient in some internal code I've been working on. In the near future, we will want to implement the equivalent of Aeson's `toEncoding` method to avoid the intermediate representation, so we should have some benchmarks up to measure the impact of this change. (I'll open an issue about this as well.)