### PR TITLE
Stricten getBoolean and getNonNegative

### DIFF
--- a/src/Data/Avro/Decode/Get.hs
+++ b/src/Data/Avro/Decode/Get.hs
@@ -127,7 +127,7 @@ getCodec code | Just "null"    <- code =
 getBoolean :: Get Bool
 getBoolean =
  do w <- G.getWord8
-    return (w == 0x01)
+    return $! (w == 0x01)
 
 -- |Get a 32-bit int (zigzag encoded, max of 5 bytes)
 getInt :: Get Int32

--- a/src/Data/Avro/DecodeRaw.hs
+++ b/src/Data/Avro/DecodeRaw.hs
@@ -12,7 +12,7 @@ import Data.Word
 getNonNegative :: (Bits i, Integral i) => Get i
 getNonNegative = do
   orig <- getWord8s
-  return (foldl' (\a x -> (a `shiftL` 7) + fromIntegral x) 0 (reverse orig))
+  return $! (foldl' (\a x -> (a `shiftL` 7) + fromIntegral x) 0 (reverse orig))
 
 getWord8s :: Get [Word8]
 getWord8s = do


### PR DESCRIPTION
I played with Tikhons benchmarks and found that they could easily be sped up.

Before:

```
decode/array/bools                       time                 24.02 ms
decode/array/ints                        time                 82.41 ms
decode/array/longs                       time                 130.7 ms
decode/array/records                     time                 311.5 ms
```

After:

```
decode/array/bools                       time                 18.46 ms
decode/array/ints                        time                 27.34 ms
decode/array/longs                       time                 34.18 ms
decode/array/records                     time                 154.0 ms
```