### PR TITLE
Vector unions

### DIFF
--- a/avro.cabal
+++ b/avro.cabal
@@ -64,6 +64,7 @@ library
       Data.Avro.DecodeRaw
       Data.Avro.Deconflict
       Data.Avro.Deriving
+      Data.Avro.Deriving.Lift
       Data.Avro.Deriving.NormSchema
       Data.Avro.EitherN
       Data.Avro.Encode

--- a/src/Data/Avro/Decode/Lazy.hs
+++ b/src/Data/Avro/Decode/Lazy.hs
@@ -322,12 +322,12 @@ getAvroOf ty0 bs = go ty0 bs
               Nothing  -> (bs', T.Error ("Unknown value {" <> show i <> "} for enum " <> Text.unpack (typeName ty) ))
               Just sym -> (bs', T.Enum ty (fromIntegral i) sym)
 
-      Union ts unionLookup ->
+      Union ts ->
         case runGetOrFail getLong bs of
           Left (bs', _, err) -> (bs', T.Error err)
           Right (bs', _, i)  ->
-            case unionLookup i of
-              Nothing -> (bs', T.Error $ "Decoded Avro tag is outside the expected range for a Union. Tag: " <> show i <> " union of: " <> show (P.map typeName $ NE.toList ts))
+            case ts V.!? (fromIntegral i) of
+              Nothing -> (bs', T.Error $ "Decoded Avro tag is outside the expected range for a Union. Tag: " <> show i <> " union of: " <> show (V.map typeName ts))
               Just t  -> T.Union ts t <$> go t bs'
 
       Fixed {..} ->

--- a/src/Data/Avro/Decode/Lazy.hs
+++ b/src/Data/Avro/Decode/Lazy.hs
@@ -318,7 +318,7 @@ getAvroOf ty0 bs = go ty0 bs
         case runGetOrFail getLong bs of
           Left (bs', _, err) -> (bs', T.Error err)
           Right (bs', _, i)  ->
-            case symbolLookup i of
+            case symbols V.!? (fromIntegral i) of
               Nothing  -> (bs', T.Error ("Unknown value {" <> show i <> "} for enum " <> Text.unpack (typeName ty) ))
               Just sym -> (bs', T.Enum ty (fromIntegral i) sym)
 

--- a/src/Data/Avro/Decode/Lazy/FromLazyAvro.hs
+++ b/src/Data/Avro/Decode/Lazy/FromLazyAvro.hs
@@ -90,9 +90,11 @@ instance FromLazyAvro Float where
   fromLazyAvro v           = badValue v "Float"
 
 instance FromLazyAvro a => FromLazyAvro (Maybe a) where
-  fromLazyAvro (T.Union (S.Null :| [_])  _ T.Null) = pure Nothing
-  fromLazyAvro (T.Union (S.Null :| [_]) _ v)       = Just <$> fromLazyAvro v
-  fromLazyAvro v                                   = badValue v "Maybe a"
+  fromLazyAvro (T.Union ts _ v) = case (V.toList ts, v) of
+    ([S.Null, _], T.Null) -> pure Nothing
+    ([S.Null, _], v')     -> Just <$> fromLazyAvro v'
+    _                     -> badValue v "Maybe a"
+  fromLazyAvro v                = badValue v "Maybe a"
 
 instance FromLazyAvro a => FromLazyAvro [a] where
   fromLazyAvro (T.Array vec) = mapM fromLazyAvro $ toList vec

--- a/src/Data/Avro/Decode/Lazy/LazyValue.hs
+++ b/src/Data/Avro/Decode/Lazy/LazyValue.hs
@@ -1,12 +1,12 @@
 module Data.Avro.Decode.Lazy.LazyValue
 where
 
-import           Data.ByteString
-import           Data.HashMap.Strict (HashMap)
-import           Data.Int
-import           Data.List.NonEmpty  (NonEmpty)
-import           Data.Text
-import           Data.Vector
+import Data.ByteString
+import Data.HashMap.Strict (HashMap)
+import Data.Int
+import Data.List.NonEmpty  (NonEmpty)
+import Data.Text
+import Data.Vector
 
 data LazyValue f
       = Null
@@ -17,11 +17,11 @@ data LazyValue f
       | Double Double
       | Bytes ByteString
       | String Text
-      | Array (Vector (LazyValue f))       -- ^ Dynamically enforced monomorphic type.
-      | Map (HashMap Text (LazyValue f))   -- ^ Dynamically enforced monomorphic type
-      | Record f (HashMap Text (LazyValue f)) -- Order and a map
-      | Union (NonEmpty f) f (LazyValue f) -- ^ Set of union options, schema for selected option, and the actual value.
+      | Array (Vector (LazyValue f))            -- ^ Dynamically enforced monomorphic type.
+      | Map (HashMap Text (LazyValue f))        -- ^ Dynamically enforced monomorphic type
+      | Record f (HashMap Text (LazyValue f))   -- ^ Order and a map
+      | Union (Vector f) f (LazyValue f)        -- ^ Set of union options, schema for selected option, and the actual value.
       | Fixed f ByteString
-      | Enum f Int Text  -- ^ An enum is a set of the possible symbols (the schema) and the selected symbol
+      | Enum f Int Text                         -- ^ An enum is a set of the possible symbols (the schema) and the selected symbol
       | Error !String
   deriving (Eq, Show)

--- a/src/Data/Avro/Decode/Strict/Internal.hs
+++ b/src/Data/Avro/Decode/Strict/Internal.hs
@@ -70,10 +70,10 @@ getAvroOf ty0 = go ty0
       do val <- getLong
          let sym = fromMaybe "" (symbolLookup val) -- empty string for 'missing' symbols (alternative is an error or exception)
          pure (T.Enum ty (fromIntegral val) sym)
-    Union ts unionLookup ->
+    Union ts ->
       do i <- getLong
-         case unionLookup i of
-          Nothing -> fail $ "Decoded Avro tag is outside the expected range for a Union. Tag: " <> show i <> " union of: " <> show (P.map typeName $ NE.toList ts)
+         case ts V.!? (fromIntegral i) of
+          Nothing -> fail $ "Decoded Avro tag is outside the expected range for a Union. Tag: " <> show i <> " union of: " <> show (V.map typeName ts)
           Just t  -> T.Union ts t <$> go t
     Fixed {..} -> T.Fixed ty <$> G.getByteString (fromIntegral size)
 

--- a/src/Data/Avro/Decode/Strict/Internal.hs
+++ b/src/Data/Avro/Decode/Strict/Internal.hs
@@ -67,9 +67,9 @@ getAvroOf ty0 = go ty0
       do let getField Field {..} = (fldName,) <$> go fldType
          T.Record ty . HashMap.fromList <$> mapM getField fields
     Enum {..} ->
-      do val <- getLong
-         let sym = fromMaybe "" (symbolLookup val) -- empty string for 'missing' symbols (alternative is an error or exception)
-         pure (T.Enum ty (fromIntegral val) sym)
+      do i <- getLong
+         let sym = fromMaybe "" (symbols V.!? (fromIntegral i)) -- empty string for 'missing' symbols (alternative is an error or exception)
+         pure (T.Enum ty (fromIntegral i) sym)
     Union ts ->
       do i <- getLong
          case ts V.!? (fromIntegral i) of

--- a/src/Data/Avro/Deconflict.hs
+++ b/src/Data/Avro/Deconflict.hs
@@ -19,6 +19,8 @@ import qualified Data.Set            as Set
 import           Data.Text           (Text)
 import qualified Data.Text           as Text
 import qualified Data.Text.Encoding  as Text
+import           Data.Vector         (Vector)
+import qualified Data.Vector         as V
 
 -- | @deconflict writer reader val@ will convert a value that was
 -- encoded/decoded with the writer's schema into the form specified by the
@@ -70,11 +72,11 @@ deconflictValue writerSchema readerSchema v
        | name a == name b && size a == size b = Right val
   go a@S.Record {} b@S.Record {} val
        | name a == name b = deconflictRecord a b val
-  go (S.Union xs _) (S.Union ys _) (T.Union _ tyVal val) =
+  go (S.Union xs) (S.Union ys) (T.Union _ tyVal val) =
        withSchemaIn tyVal xs $ \sch -> deconflictReaderUnion sch ys val
-  go nonUnion (S.Union ys _) val =
+  go nonUnion (S.Union ys) val =
        deconflictReaderUnion nonUnion ys val
-  go (S.Union xs _) nonUnion (T.Union _ tyVal val) =
+  go (S.Union xs) nonUnion (T.Union _ tyVal val) =
        withSchemaIn tyVal xs $ \sch -> deconflictValue sch nonUnion val
   go eTy dTy val =
     case val of
@@ -104,14 +106,14 @@ withSchemaIn schema schemas f =
     Nothing    -> Left $ "Incorrect payload: union " <> (show . Foldable.toList $ typeName <$> schemas) <> " does not contain schema " <> Text.unpack (typeName schema)
     Just found -> f found
 
-deconflictReaderUnion :: Type -> NonEmpty Type -> T.Value Type -> Either String (T.Value Type)
+deconflictReaderUnion :: Type -> Vector Type -> T.Value Type -> Either String (T.Value Type)
 deconflictReaderUnion valueSchema unionTypes val =
     let hdl [] = Left "Impossible: empty non-empty list."
         hdl (d:rest) =
               case deconflictValue valueSchema d val of
                 Right v -> Right (T.Union unionTypes d v)
                 Left _  -> hdl rest
-    in hdl (NE.toList unionTypes)
+    in hdl (V.toList unionTypes)
 
 deconflictRecord :: Type -> Type -> T.Value Type -> Either String (T.Value Type)
 deconflictRecord writerSchema readerSchema (T.Record ty fldVals)  =

--- a/src/Data/Avro/Deriving/Lift.hs
+++ b/src/Data/Avro/Deriving/Lift.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE DeriveLift         #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TemplateHaskell    #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+module Data.Avro.Deriving.Lift
+where
+
+import qualified Data.Avro.Schema           as Schema
+import qualified Data.Avro.Types.Value      as Avro
+import qualified Data.ByteString            as ByteString
+import qualified Data.HashMap.Strict        as HashMap
+import qualified Data.Text                  as Text
+import qualified Data.Vector                as Vector
+import           Language.Haskell.TH.Syntax (Lift (..))
+
+instance Lift ByteString.ByteString where
+  lift b = [| ByteString.pack $(lift $ ByteString.unpack b) |]
+
+instance Lift Text.Text where
+  lift t = [| Text.pack $(lift $ Text.unpack t) |]
+
+instance Lift a => Lift (Vector.Vector a) where
+  lift v = [| Vector.fromList $(lift $ Vector.toList v) |]
+
+instance (Lift k, Lift v) => Lift (HashMap.HashMap k v) where
+  lift m = [| HashMap.fromList $(lift $ HashMap.toList m) |]
+
+deriving instance Lift f => Lift (Avro.Value f)
+deriving instance Lift Schema.Field
+deriving instance Lift Schema.Order
+deriving instance Lift Schema.TypeName
+deriving instance Lift Schema.Type

--- a/src/Data/Avro/EitherN.hs
+++ b/src/Data/Avro/EitherN.hs
@@ -214,27 +214,27 @@ instance (FromLazyAvro a, FromLazyAvro b, FromLazyAvro c, FromLazyAvro d, FromLa
 
 instance (ToAvro a, ToAvro b, ToAvro c) => ToAvro (Either3 a b c) where
   toAvro e =
-    let sch@(one :| [two, three]) = options (schemaOf e)
+    let sch = options (schemaOf e)
     in case e of
-      E3_1 a -> T.Union sch one   (toAvro a)
-      E3_2 b -> T.Union sch two   (toAvro b)
-      E3_3 c -> T.Union sch three (toAvro c)
+      E3_1 a -> T.Union sch (schemaOf a) (toAvro a)
+      E3_2 b -> T.Union sch (schemaOf b) (toAvro b)
+      E3_3 c -> T.Union sch (schemaOf c) (toAvro c)
 
 instance (ToAvro a, ToAvro b, ToAvro c, ToAvro d) => ToAvro (Either4 a b c d) where
   toAvro e =
-    let sch@(one :| [two, three, four]) = options (schemaOf e)
+    let sch = options (schemaOf e)
     in case e of
-      E4_1 a -> T.Union sch one   (toAvro a)
-      E4_2 b -> T.Union sch two   (toAvro b)
-      E4_3 c -> T.Union sch three (toAvro c)
-      E4_4 d -> T.Union sch four  (toAvro d)
+      E4_1 a -> T.Union sch (schemaOf a) (toAvro a)
+      E4_2 b -> T.Union sch (schemaOf b) (toAvro b)
+      E4_3 c -> T.Union sch (schemaOf c) (toAvro c)
+      E4_4 d -> T.Union sch (schemaOf d) (toAvro d)
 
 instance (ToAvro a, ToAvro b, ToAvro c, ToAvro d, ToAvro e) => ToAvro (Either5 a b c d e) where
   toAvro e =
-    let sch@(one :| [two, three, four, five]) = options (schemaOf e)
+    let sch = options (schemaOf e)
     in case e of
-      E5_1 a -> T.Union sch one   (toAvro a)
-      E5_2 b -> T.Union sch two   (toAvro b)
-      E5_3 c -> T.Union sch three (toAvro c)
-      E5_4 d -> T.Union sch four  (toAvro d)
-      E5_5 e -> T.Union sch five  (toAvro e)
+      E5_1 a -> T.Union sch (schemaOf a) (toAvro a)
+      E5_2 b -> T.Union sch (schemaOf b) (toAvro b)
+      E5_3 c -> T.Union sch (schemaOf c) (toAvro c)
+      E5_4 d -> T.Union sch (schemaOf d) (toAvro d)
+      E5_5 e -> T.Union sch (schemaOf e) (toAvro e)

--- a/src/Data/Avro/Encode.hs
+++ b/src/Data/Avro/Encode.hs
@@ -52,9 +52,9 @@ import qualified Data.Text.Lazy.Encoding    as TL
 import qualified Data.Vector                as V
 import qualified Data.Vector.Unboxed        as U
 import           Data.Word
+import           Prelude                    as P
 import           System.Random.TF.Init      (initTFGen)
 import           System.Random.TF.Instances (randoms)
-import           Prelude                    as P
 
 import Data.Avro.Codec
 import Data.Avro.EncodeRaw
@@ -295,8 +295,8 @@ instance EncodeAvro (T.Value Type) where
             fs = P.map fldName (fields ty)
         in AvroM (bs, ty)
       T.Union opts sel val | F.length opts > 0 ->
-        case DL.elemIndex sel (NE.toList opts) of
-          Just idx -> AvroM (putI idx <> putAvro val, S.mkUnion opts)
+        case V.elemIndex sel opts of
+          Just idx -> AvroM (putI idx <> putAvro val, S.Union opts)
           Nothing  -> error "Union encoding specifies type not found in schema"
       T.Enum sch@S.Enum{..} ix t -> AvroM (putI ix, sch)
       T.Fixed ty bs  ->

--- a/src/Data/Avro/FromAvro.hs
+++ b/src/Data/Avro/FromAvro.hs
@@ -84,9 +84,11 @@ instance FromAvro Float where
   fromAvro v           = badValue v "Float"
 
 instance FromAvro a => FromAvro (Maybe a) where
-  fromAvro (T.Union (S.Null :| [_])  _ T.Null) = pure Nothing
-  fromAvro (T.Union (S.Null :| [_]) _ v)       = Just <$> fromAvro v
-  fromAvro v                                   = badValue v "Maybe a"
+  fromAvro (T.Union ts _ v) = case (V.toList ts, v) of
+    ([S.Null, _], T.Null) -> pure Nothing
+    ([S.Null, _], v')     -> Just <$> fromAvro v'
+    _                     -> badValue v "Maybe a"
+  fromAvro v                = badValue v "Maybe a"
 
 instance FromAvro a => FromAvro [a] where
   fromAvro (T.Array vec) = mapM fromAvro $ toList vec

--- a/src/Data/Avro/HasAvroSchema.hs
+++ b/src/Data/Avro/HasAvroSchema.hs
@@ -84,7 +84,7 @@ instance HasAvroSchema BL.ByteString where
   schema = Tagged S.Bytes
 
 instance (HasAvroSchema a, HasAvroSchema b) => HasAvroSchema (Either a b) where
-  schema = Tagged $ mkUnion (untag (schema :: Tagged a Type) :| [untag (schema :: Tagged b Type)])
+  schema = Tagged $ S.Union $ V.fromListN 2 [untag (schema :: Tagged a Type), untag (schema :: Tagged b Type)]
 
 instance (HasAvroSchema a) => HasAvroSchema (Map.Map Text a) where
   schema = wrapTag S.Map (schema :: Tagged a Type)

--- a/src/Data/Avro/JSON.hs
+++ b/src/Data/Avro/JSON.hs
@@ -59,7 +59,7 @@
 -- @
 module Data.Avro.JSON where
 
-import           Data.Semigroup       ((<>))
+import Data.Semigroup ((<>))
 
 import qualified Data.Aeson           as Aeson
 import           Data.ByteString.Lazy (ByteString)
@@ -70,11 +70,12 @@ import qualified Data.List.NonEmpty   as NE
 import           Data.Tagged
 import qualified Data.Text            as Text
 
-import           Data.Avro            (FromAvro (..), Result (..), ToAvro (..))
-import qualified Data.Avro            as Avro
-import           Data.Avro.Schema     (Schema, parseAvroJSON)
-import qualified Data.Avro.Schema     as Schema
-import qualified Data.Avro.Types      as Avro
+import           Data.Avro        (FromAvro (..), Result (..), ToAvro (..))
+import qualified Data.Avro        as Avro
+import           Data.Avro.Schema (Schema, parseAvroJSON)
+import qualified Data.Avro.Schema as Schema
+import qualified Data.Avro.Types  as Avro
+import qualified Data.Vector      as V
 
 decodeAvroJSON :: Schema -> Aeson.Value -> Result (Avro.Value Schema)
 decodeAvroJSON schema json =
@@ -85,12 +86,12 @@ decodeAvroJSON schema json =
     missing name =
       fail ("Type " <> show name <> " not in schema")
 
-    union (Schema.Union schemas _) Aeson.Null
+    union (Schema.Union schemas) Aeson.Null
       | Schema.Null `elem` schemas =
           pure $ Avro.Union schemas Schema.Null Avro.Null
       | otherwise                  =
           fail "Null not in union."
-    union (Schema.Union schemas _) (Aeson.Object obj)
+    union (Schema.Union schemas) (Aeson.Object obj)
       | null obj =
           fail "Invalid encoding of union: empty object ({})."
       | length obj > 1 =
@@ -103,7 +104,7 @@ decodeAvroJSON schema json =
             branch =
               head $ HashMap.keys obj
             names =
-              HashMap.fromList [(Schema.typeName t, t) | t <- NE.toList schemas]
+              HashMap.fromList [(Schema.typeName t, t) | t <- V.toList schemas]
           in case HashMap.lookup (canonicalize branch) names of
             Just t  -> do
               nested <- parseAvroJSON union env t (obj ! branch)

--- a/src/Data/Avro/Schema.hs
+++ b/src/Data/Avro/Schema.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveAnyClass        #-}
 {-# LANGUAGE DeriveGeneric         #-}
+{-# LANGUAGE DeriveLift            #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -82,8 +83,6 @@ import qualified Data.Vector            as V
 import           Prelude                as P
 
 import GHC.Generics (Generic)
-
-import Text.Show.Functions ()
 
 -- | An Avro schema is either
 --

--- a/src/Data/Avro/Schema.hs
+++ b/src/Data/Avro/Schema.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DeriveAnyClass        #-}
 {-# LANGUAGE DeriveGeneric         #-}
-{-# LANGUAGE DeriveLift            #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -9,7 +8,6 @@
 {-# LANGUAGE RecordWildCards       #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE TupleSections         #-}
-{-# LANGUAGE TypeSynonymInstances  #-}
 {-# LANGUAGE ViewPatterns          #-}
 
 -- | Avro 'Schema's, represented here as values of type 'Schema',

--- a/src/Data/Avro/ToAvro.hs
+++ b/src/Data/Avro/ToAvro.hs
@@ -1,27 +1,27 @@
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE ConstraintKinds     #-}
+{-# LANGUAGE FlexibleInstances   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 module Data.Avro.ToAvro
 
 where
 
-import           Control.Arrow        (first)
+import           Control.Arrow           (first)
 import           Data.Avro.HasAvroSchema
-import           Data.Avro.Schema     as S
-import           Data.Avro.Types      as T
-import qualified Data.ByteString      as B
-import           Data.ByteString.Lazy (ByteString)
-import qualified Data.ByteString.Lazy as BL
-import qualified Data.HashMap.Strict  as HashMap
+import           Data.Avro.Schema        as S
+import           Data.Avro.Types         as T
+import qualified Data.ByteString         as B
+import           Data.ByteString.Lazy    (ByteString)
+import qualified Data.ByteString.Lazy    as BL
+import qualified Data.HashMap.Strict     as HashMap
 import           Data.Int
-import           Data.List.NonEmpty (NonEmpty(..))
-import qualified Data.Map             as Map
-import           Data.Text            (Text)
-import qualified Data.Text            as Text
-import qualified Data.Text.Lazy       as TL
+import           Data.List.NonEmpty      (NonEmpty (..))
+import qualified Data.Map                as Map
 import           Data.Tagged
-import qualified Data.Vector          as V
-import qualified Data.Vector.Unboxed  as U
+import           Data.Text               (Text)
+import qualified Data.Text               as Text
+import qualified Data.Text.Lazy          as TL
+import qualified Data.Vector             as V
+import qualified Data.Vector.Unboxed     as U
 import           Data.Word
 
 class HasAvroSchema a => ToAvro a where
@@ -65,10 +65,10 @@ instance ToAvro BL.ByteString where
 
 instance (ToAvro a, ToAvro b) => ToAvro (Either a b) where
   toAvro e =
-    let sch@(l:|[r]) = options (schemaOf e)
+    let sch = options (schemaOf e)
     in case e of
-         Left a  -> T.Union sch l (toAvro a)
-         Right b -> T.Union sch r (toAvro b)
+         Left a  -> T.Union sch (schemaOf a) (toAvro a)
+         Right b -> T.Union sch (schemaOf b) (toAvro b)
 
 instance (ToAvro a) => ToAvro (Map.Map Text a) where
   toAvro = toAvro . HashMap.fromList . Map.toList
@@ -90,10 +90,10 @@ instance (ToAvro a) => ToAvro (HashMap.HashMap String a) where
 
 instance (ToAvro a) => ToAvro (Maybe a) where
   toAvro a =
-    let sch@(l:|[r]) = options (schemaOf a)
+    let sch = options (schemaOf a)
     in case a of
       Nothing -> T.Union sch S.Null (toAvro ())
-      Just v  -> T.Union sch r (toAvro v)
+      Just v  -> T.Union sch (schemaOf v) (toAvro v)
 
 instance (ToAvro a) => ToAvro [a] where
   toAvro = T.Array . V.fromList . (toAvro <$>)

--- a/src/Data/Avro/Types/Value.hs
+++ b/src/Data/Avro/Types/Value.hs
@@ -2,16 +2,16 @@
 {-# LANGUAGE DeriveGeneric  #-}
 module Data.Avro.Types.Value where
 
-import           Control.DeepSeq     (NFData)
+import Control.DeepSeq (NFData)
 
-import           Data.ByteString
-import           Data.HashMap.Strict (HashMap)
-import           Data.Int
-import           Data.List.NonEmpty  (NonEmpty)
-import           Data.Text
-import           Data.Vector
+import Data.ByteString
+import Data.HashMap.Strict (HashMap)
+import Data.Int
+import Data.List.NonEmpty  (NonEmpty)
+import Data.Text
+import Data.Vector
 
-import           GHC.Generics        (Generic)
+import GHC.Generics (Generic)
 
 data Value f
       = Null
@@ -25,7 +25,7 @@ data Value f
       | Array (Vector (Value f))       -- ^ Dynamically enforced monomorphic type.
       | Map (HashMap Text (Value f))   -- ^ Dynamically enforced monomorphic type
       | Record f (HashMap Text (Value f)) -- Order and a map
-      | Union (NonEmpty f) f (Value f) -- ^ Set of union options, schema for selected option, and the actual value.
+      | Union (Vector f) f (Value f) -- ^ Set of union options, schema for selected option, and the actual value.
       | Fixed f {-# UNPACK #-} !ByteString
       | Enum f {-# UNPACK #-} !Int Text  -- ^ An enum is a set of the possible symbols (the schema) and the selected symbol
   deriving (Eq, Show, Generic, NFData)

--- a/test/Avro/DefaultsSpec.hs
+++ b/test/Avro/DefaultsSpec.hs
@@ -14,7 +14,7 @@ import qualified Data.HashMap.Strict as M
 import           Data.List.NonEmpty  (NonEmpty (..))
 import qualified Data.Vector         as V
 
-import           Test.Hspec
+import Test.Hspec
 
 {-# ANN module ("HLint: ignore Redundant do"        :: String) #-}
 
@@ -35,7 +35,7 @@ spec = describe "Avro.DefaultsSpec: Schema with named types" $ do
       msgSchema = schemaOf (undefined :: MaybeTest)
       fixedSchema = schemaOf (undefined :: FixedTag)
       defaults = fldDefault <$> fields msgSchema
-    in defaults `shouldBe` [ Just $ Ty.Union (Null :| [String]) Null Ty.Null
+    in defaults `shouldBe` [ Just $ Ty.Union (V.fromList [Null, String]) Null Ty.Null
                            , Just $ Ty.Fixed fixedSchema "\0\42\255"
                            , Just $ Ty.Bytes "\0\37\255"
                            ]

--- a/test/Avro/THUnionSpec.hs
+++ b/test/Avro/THUnionSpec.hs
@@ -5,7 +5,7 @@
 module Avro.THUnionSpec
 where
 
-import qualified Data.List.NonEmpty   as NE
+import qualified Data.List.NonEmpty as NE
 
 import qualified Data.Aeson           as Aeson
 import           Data.Avro
@@ -15,12 +15,13 @@ import qualified Data.Avro.Schema     as Schema
 import qualified Data.Avro.Types      as Avro
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Map             as Map
+import qualified Data.Vector          as V
 
-import           System.Directory     (doesFileExist)
+import System.Directory (doesFileExist)
 
-import           Test.Hspec
+import Test.Hspec
 
-import           Paths_avro
+import Paths_avro
 
 deriveAvro "test/data/unions.avsc"
 
@@ -67,8 +68,8 @@ spec = describe "Avro.THUnionSpec: Schema with unions." $ do
         , field "four"  (Schema.mkUnion (NE.fromList [Schema.Int, Schema.String, Schema.Long, foo]))         Nothing
         , field "five"  (Schema.mkUnion (NE.fromList [Schema.Int, Schema.String, Schema.Long, foo, notFoo])) Nothing
         ]
-      scalarsDefault  = Just $ Avro.Union (NE.fromList [Schema.String, Schema.Long]) Schema.String (Avro.String "foo")
-      nullableDefault = Just $ Avro.Union (NE.fromList [Schema.Null, Schema.Int])    Schema.Null   Avro.Null
+      scalarsDefault  = Just $ Avro.Union (V.fromList [Schema.String, Schema.Long]) Schema.String (Avro.String "foo")
+      nullableDefault = Just $ Avro.Union (V.fromList [Schema.Null, Schema.Int])    Schema.Null   Avro.Null
 
       fooSchema = record "haskell.avro.example.Foo" [field "stuff" Schema.String Nothing]
       barSchema = record "haskell.avro.example.Bar"


### PR DESCRIPTION
## Changes

- Instead of lists, use `Vector` for `Union` and `Enum`. `Vector` provides `O(1)` indexed access access and eliminate the need for lookup functions in `Schema`. This also adresses  https://github.com/haskell-works/avro/issues/81

- Lift `Schema` to TS instead of manually recreating it. It requires a bunch of orphan `Lift` instances, but I think it is OK since it is just a TH deriving stuff.