### PR TITLE
Re-enable binary caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  haskell: haskell-works/haskell-build-2@1.6.16
+  haskell: haskell-works/haskell-build-2@1.6.17
   github: haskell-works/github-release@1.2.1
   hackage: haskell-works/hackage@1.1.0
 
@@ -12,16 +12,19 @@ workflows:
           name: GHC 8.4.4
           executor: haskell/ghc-8_4_4
           context: haskell-ci
+          binary-cache-uri: ${BINARY_CACHE_URI-"http://hw-binary-cache-us-west-2-a.s3-website-us-west-2.amazonaws.com/archive"}
 
       - haskell/build:
           name: GHC 8.6.4
           executor: haskell/ghc-8_6_4
           context: haskell-ci
+          binary-cache-uri: ${BINARY_CACHE_URI-"http://hw-binary-cache-us-west-2-a.s3-website-us-west-2.amazonaws.com/archive"}
 
       - haskell/build:
           name: GHC 7.10.3
           executor: haskell/ghc-7_10_3
           context: haskell-ci
+          binary-cache-uri: ${BINARY_CACHE_URI-"http://hw-binary-cache-us-west-2-a.s3-website-us-west-2.amazonaws.com/archive"}
 
       - github/release-cabal:
           context: haskell-ci


### PR DESCRIPTION
Evidence of successful restore in forked repo is here: https://circleci.com/gh/newhoggy/avro/59

However, the account within which the bucket resides has been locked down and I won't be able to set it up properly maybe until Monday.

The implication of this PR is that forked repos will get to use haskell-works' binary cache in read-only mode out of the box.  This also means that CI builds in forked repos will not be able to save their cache so changes to dependencies for example by editing the cabal file may cause some packages to not cache.

This is probably a satisfactory out-of-the-box experience.

Contributors who want to use their own binary cache may supply their own bucket config via the `haskell-ci` context.