### PR TITLE
Remove comment in splice

### DIFF
--- a/src/Data/Avro/Deriving.hs
+++ b/src/Data/Avro/Deriving.hs
@@ -462,7 +462,7 @@ schemaDef :: Name -> Schema -> Q [Dec]
 schemaDef sname sch = setName sname $
   [d|
       x :: Schema
-      x = sch -- $(schemaDef' sch)
+      x = sch
   |]
 
 -- | A hack around TemplateHaskell limitation:


### PR DESCRIPTION
Haddock doesn't like it and fails because it thinks it's section syntax:

```
src/Data/Avro/Deriving.hs:465:15: error:
    parse error on input ‘-- $(schemaDef' sch)’
    |
465 |       x = sch -- $(schemaDef' sch)
    |               ^^^^^^^^^^^^^^^^^^^^
```