### PR TITLE
Make deconflicting properly recursive

### DIFF
--- a/avro.cabal
+++ b/avro.cabal
@@ -203,6 +203,8 @@ test-suite test
       Avro.Deconflict.B.Writer
       Avro.Deconflict.C.Reader
       Avro.Deconflict.C.Writer
+      Avro.Deconflict.D.Reader
+      Avro.Deconflict.D.Writer
       Avro.DeconflictSpec
       Avro.DefaultsSpec
       Avro.EncodeRawSpec

--- a/src/Data/Avro.hs
+++ b/src/Data/Avro.hs
@@ -131,11 +131,9 @@ decodeContainerWithSchema readerSchema bs =
   case D.decodeContainer bs of
     Right (writerSchema,val) ->
       let
-        writerSchema' = S.expandNamedTypes writerSchema
-        readerSchema' = S.expandNamedTypes readerSchema
         err e = error $ "Could not deconflict reader and writer schema." <> e
         dec x =
-          case C.deconflictNoResolve writerSchema' readerSchema' x of
+          case C.deconflict writerSchema readerSchema x of
             Left e   -> err e
             Right v  -> case fromAvro v of
                           Success x -> x

--- a/src/Data/Avro/Decode/Lazy.hs
+++ b/src/Data/Avro/Decode/Lazy.hs
@@ -125,11 +125,9 @@ decodeContainerWithSchema s bs =
 decodeContainerWithSchema' :: FromLazyAvro a => Schema -> BL.ByteString -> Either String [[Either String a]]
 decodeContainerWithSchema' readerSchema bs = do
   (writerSchema, vals) <- getContainerValues bs
-  let writerSchema' = S.expandNamedTypes writerSchema
-  let readerSchema' = S.expandNamedTypes readerSchema
-  pure $ (fmap . fmap) (convertValue writerSchema' readerSchema') vals
+  pure $ (fmap . fmap) (convertValue writerSchema readerSchema) vals
   where
-    convertValue w r v = resultToEither $ fromLazyAvro (C.deconflictNoResolve w r v)
+    convertValue w r v = resultToEither $ fromLazyAvro (C.deconflict w r v)
 
 -- |Decode bytes into a 'Value' as described by Schema.
 decodeAvro :: Schema -> BL.ByteString -> T.LazyValue Type

--- a/src/Data/Avro/Deconflict.hs
+++ b/src/Data/Avro/Deconflict.hs
@@ -22,6 +22,12 @@ import qualified Data.Text.Encoding  as Text
 import           Data.Vector         (Vector)
 import qualified Data.Vector         as V
 
+type Deconflicter =
+     Schema        -- ^ Writer schema
+  -> Schema        -- ^ Reader schema
+  -> T.Value Type
+  -> Either String (T.Value Type)
+
 -- | @deconflict writer reader val@ will convert a value that was
 -- encoded/decoded with the writer's schema into the form specified by the
 -- reader's schema.
@@ -33,8 +39,7 @@ deconflict :: Schema        -- ^ Writer schema
            -> Schema        -- ^ Reader schema
            -> T.Value Type
            -> Either String (T.Value Type)
-deconflict writerSchema readerSchema =
-  deconflictNoResolve (S.expandNamedTypes writerSchema) (S.expandNamedTypes readerSchema)
+deconflict = startDeconflict True
 
 -- | @deconflict writer reader val@ will convert a value that was
 -- encoded/decoded with the writer's schema into the form specified by the
@@ -50,18 +55,17 @@ deconflictNoResolve :: Schema         -- ^ Writer schema
                     -> Schema         -- ^ Reader schema
                     -> T.Value Type
                     -> Either String (T.Value Type)
-deconflictNoResolve writerSchema readerSchema =
-  deconflictValue writerSchema readerSchema
+deconflictNoResolve = startDeconflict False
 
-deconflictValue :: Schema
-              -> Schema
-              -> T.Value Type
-              -> Either String (T.Value Type)
-deconflictValue writerSchema readerSchema v
-  | writerSchema == readerSchema    = Right v
-  | otherwise = go writerSchema readerSchema v
+
+startDeconflict :: Bool -> Deconflicter
+startDeconflict shouldExpandNames writerSchema readerSchema = go writerSchema readerSchema
   where
-  go :: Type -> Type -> T.Value Type -> Either String (T.Value Type)
+  aEnv = S.buildTypeEnvironment (const $ Left "Bad Schema") writerSchema
+  bEnv = S.buildTypeEnvironment (const $ Left "Bad Schema") readerSchema
+  go :: Deconflicter
+  go aTy bTy val
+    | not shouldExpandNames && aTy == bTy = Right val
   go (S.Array aTy) (S.Array bTy) (T.Array vec) =
        T.Array <$> mapM (go aTy bTy) vec
   go (S.Map aTy) (S.Map bTy) (T.Map mp)    =
@@ -71,22 +75,29 @@ deconflictValue writerSchema readerSchema v
   go a@S.Fixed {} b@S.Fixed {} val
        | name a == name b && size a == size b = Right val
   go a@S.Record {} b@S.Record {} val
-       | name a == name b = deconflictRecord a b val
+       | name a == name b = deconflictRecord go a b val
   go (S.Union xs) (S.Union ys) (T.Union _ tyVal val) =
-       withSchemaIn tyVal xs $ \sch -> deconflictReaderUnion sch ys val
+       withSchemaIn tyVal xs $ \sch -> deconflictReaderUnion go sch ys val
   go nonUnion (S.Union ys) val =
-       deconflictReaderUnion nonUnion ys val
+       deconflictReaderUnion go nonUnion ys val
   go (S.Union xs) nonUnion (T.Union _ tyVal val) =
-       withSchemaIn tyVal xs $ \sch -> deconflictValue sch nonUnion val
+       withSchemaIn tyVal xs $ \sch -> go sch nonUnion val
+  go (S.NamedType t) bTy val = do
+       aTy <- aEnv t
+       go aTy bTy val
+  go aTy (S.NamedType t) val = do
+       bTy <- bEnv t
+       go aTy bTy val
+  go aTy bTy val | aTy == bTy = Right val
   go eTy dTy val =
     case val of
       T.Int i32  | dTy == S.Long   -> Right $ T.Long   (fromIntegral i32)
                  | dTy == S.Float  -> Right $ T.Float  (fromIntegral i32)
                  | dTy == S.Double -> Right $ T.Double (fromIntegral i32)
-      T.Long i64 | dTy == S.Float  -> Right $ T.Float (fromIntegral i64)
+      T.Long i64 | dTy == S.Float  -> Right $ T.Float  (fromIntegral i64)
                  | dTy == S.Double -> Right $ T.Double (fromIntegral i64)
       T.Float f  | dTy == S.Double -> Right $ T.Double (realToFrac f)
-      T.String s | dTy == S.Bytes  -> Right $ T.Bytes (Text.encodeUtf8 s)
+      T.String s | dTy == S.Bytes  -> Right $ T.Bytes  (Text.encodeUtf8 s)
       T.Bytes bs | dTy == S.String -> Right $ T.String (Text.decodeUtf8 bs)
       _                            -> Left $ "Can not resolve differing writer and reader schemas: " ++ show (eTy, dTy)
 
@@ -106,32 +117,32 @@ withSchemaIn schema schemas f =
     Nothing    -> Left $ "Incorrect payload: union " <> (show . Foldable.toList $ typeName <$> schemas) <> " does not contain schema " <> Text.unpack (typeName schema)
     Just found -> f found
 
-deconflictReaderUnion :: Type -> Vector Type -> T.Value Type -> Either String (T.Value Type)
-deconflictReaderUnion valueSchema unionTypes val =
+deconflictReaderUnion :: Deconflicter -> Type -> Vector Type -> T.Value Type -> Either String (T.Value Type)
+deconflictReaderUnion go valueSchema unionTypes val =
     let hdl [] = Left "Impossible: empty non-empty list."
         hdl (d:rest) =
-              case deconflictValue valueSchema d val of
+              case go valueSchema d val of
                 Right v -> Right (T.Union unionTypes d v)
                 Left _  -> hdl rest
     in hdl (V.toList unionTypes)
 
-deconflictRecord :: Type -> Type -> T.Value Type -> Either String (T.Value Type)
-deconflictRecord writerSchema readerSchema (T.Record ty fldVals)  =
-  T.Record readerSchema . HashMap.fromList <$> mapM (deconflictFields fldVals (fields writerSchema)) (fields readerSchema)
+deconflictRecord :: Deconflicter -> Type -> Type -> T.Value Type -> Either String (T.Value Type)
+deconflictRecord go writerSchema readerSchema (T.Record ty fldVals)  =
+  T.Record readerSchema . HashMap.fromList <$> mapM (deconflictFields go fldVals (fields writerSchema)) (fields readerSchema)
 
 -- For each field of the decoders, lookup the field in the hash map
---  1) If the field exists, call 'deconflictValue'
+--  1) If the field exists, call the given deconflicting function
 --  2) If the field is missing use the reader's default
 --  3) If there is no default, fail.
 --
 -- XXX: Consider aliases in the writer schema, use those to retry on failed lookup.
-deconflictFields :: HashMap Text (T.Value Type) -> [Field] -> Field -> Either String (Text,T.Value Type)
-deconflictFields hm writerFields readerField =
+deconflictFields :: Deconflicter -> HashMap Text (T.Value Type) -> [Field] -> Field -> Either String (Text,T.Value Type)
+deconflictFields go hm writerFields readerField =
   let
     mbWriterField = findField readerField writerFields
     mbValue = HashMap.lookup (fldName readerField) hm
   in case (mbWriterField, mbValue, fldDefault readerField) of
-    (Just w, Just x,_)  -> (fldName readerField,) <$> deconflictValue (fldType w) (fldType readerField) x
+    (Just w, Just x,_)  -> (fldName readerField,) <$> go (fldType w) (fldType readerField) x
     (_, Just x,_)       -> Right (fldName readerField, x)
     (_, _,Just def)     -> Right (fldName readerField, def)
     (_,Nothing,Nothing) -> Left $ "No field and no default for " ++ show (fldName readerField)

--- a/src/Data/Avro/Schema.hs
+++ b/src/Data/Avro/Schema.hs
@@ -603,6 +603,8 @@ parseAvroJSON union env ty av                  =
             when (len /= size) $
               fail $ "Fixed string wrong size. Expected " <> show size <> " but got " <> show len
             return $ Ty.Fixed ty bytes
+          _ -> fail $ "Expected type String, Enum, Bytes, or Fixed, but found (Type,Value)="
+             <> show (ty, av)
       A.Bool b       -> case ty of
                           Boolean -> return $ Ty.Boolean b
                           _       -> avroTypeMismatch ty "boolean"

--- a/test/Avro/Deconflict/B/README.md
+++ b/test/Avro/Deconflict/B/README.md
@@ -1,1 +1,1 @@
-# Adding an nested optional field
+# Adding a nested optional field

--- a/test/Avro/Deconflict/C/README.md
+++ b/test/Avro/Deconflict/C/README.md
@@ -1,1 +1,1 @@
-# Removing an nested optional field
+# Removing a nested optional field

--- a/test/Avro/Deconflict/D/README.md
+++ b/test/Avro/Deconflict/D/README.md
@@ -1,0 +1,1 @@
+# Adding a recursive optional field

--- a/test/Avro/Deconflict/D/Reader.hs
+++ b/test/Avro/Deconflict/D/Reader.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes       #-}
+{-# LANGUAGE TemplateHaskell   #-}
+
+module Avro.Deconflict.D.Reader where
+
+import Data.Avro.Deriving
+import Text.RawString.QQ
+
+deriveAvroFromByteString [r|
+[
+{ "name": "Foo",
+  "type": "record",
+  "fields": [
+    { "name": "constructor",
+      "type": [
+        { "name": "Bar",
+          "type": "record",
+          "fields": [
+            { "name": "fieldA", "type": "int" },
+            { "name": "fieldB", "type": [ "null", "string" ], "default": null }
+          ]
+        },
+        { "name": "Baz",
+          "type": "record",
+          "fields": [
+            { "name": "fieldC", "type": "Foo" }
+          ]
+        }
+      ]
+    }
+  ]
+}
+]
+|]
+
+sampleValue :: Foo
+sampleValue =
+  Foo (Right (Baz (Foo (Right (Baz (Foo (Left $ Bar 12 Nothing)))))))

--- a/test/Avro/Deconflict/D/Writer.hs
+++ b/test/Avro/Deconflict/D/Writer.hs
@@ -1,0 +1,39 @@
+{-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes       #-}
+{-# LANGUAGE TemplateHaskell   #-}
+
+module Avro.Deconflict.D.Writer where
+
+import Data.Avro.Deriving
+import Text.RawString.QQ
+
+deriveAvroFromByteString [r|
+[
+{ "name": "Foo",
+  "type": "record",
+  "fields": [
+    { "name": "constructor",
+      "type": [
+        { "name": "Bar",
+          "type": "record",
+          "fields": [
+            { "name": "fieldA", "type": "int" }
+          ]
+        },
+        { "name": "Baz",
+          "type": "record",
+          "fields": [
+            { "name": "fieldC", "type": "Foo" }
+          ]
+        }
+      ]
+    }
+  ]
+}
+]
+|]
+
+sampleValue :: Foo
+sampleValue =
+  Foo (Right (Baz (Foo (Right (Baz (Foo (Left $ Bar 12)))))))


### PR DESCRIPTION
## Description
In PR https://github.com/haskell-works/avro/pull/94, `deconflict` was updated to do some name resolution.  As the PR describes:

> The problem is that `deconflict` doesn't expand `TypedName` when traversing schemas. It only checks if the name matches, and if it does then it assumes that the value doesn't need to be deconflicted.

However, that PR does not go quite far enough.  The solution in that PR is to call `expandNamedTypes` (a function introduced in the PR) on the schemas before deconflicting.  This expands any found names, but it does not expand names that may come from other expanded names; in other words, it does not work on recursive data types.  See the new test cases derived from the modules  `Avro.Deconflict.D.Writer` and `Avro.Deconflict.D.Reader` for an example of this.

## Changes
In this PR, I have updated `deconflict` to carry around name-resolution environments (created by the `buildTypeEnvironment` function in `Data.Avro.Schema`), which it can use to dynamically look up names when they are found.  This additionally means that initial passes of `expandNamedTypes` are no longer necessary.

In PR https://github.com/haskell-works/avro/pull/94, there was a warning that expanding names increased the runtime of `deconflict`.  Fortunately, according to the benchmark suite, dynamic name resolution doesn't seem to make `deconflict` any slower.  However, it does make `deconflictNoResolve` about 15% slower.  Of course, this could probably be solved with a lot of code duplication (use entirely different functions for `deconflict` and `deconflictNoResolve`), but this seems ugly.  Perhaps a reviewer can see a way to make my code faster?

That said, it strikes me that `deconflictNoResolve` is, well, wrong, and I can't see any place where it should safely be used.  In PR https://github.com/haskell-works/avro/pull/94, it was argued that it could still be used when decoding containers, but as my test cases show, this isn't true in a general case.  It seems to me that any sort of performance hit is simply the price that must be paid for supporting recursive types (although it would be great if I were wrong about this).

### Final Notes
Thanks for considering this code, and since I didn't see any PR guidelines, please let me know if there's anything I can do to make it more acceptable.