### PR TITLE
Expand enums in expandNamedTypes

### DIFF
--- a/src/Data/Avro/Schema.hs
+++ b/src/Data/Avro/Schema.hs
@@ -764,6 +764,10 @@ expandNamedTypes =
         modify' (HashMap.insert name r')
         pure r'
 
+      r@Enum{name} -> do
+        modify' (HashMap.insert name r)
+        pure r
+
       other -> pure other
 
 -- | Merge two schemas to produce a third.


### PR DESCRIPTION
In the definition of `expandNamedTypes` enumerations are not resolved. This commit fixes the problem by simply adding them to the map while traversing it.