### PR TITLE
Schema Deconflict

### DIFF
--- a/avro.cabal
+++ b/avro.cabal
@@ -139,6 +139,7 @@ library
                         Data.Avro.HasAvroSchema
                         Data.Avro.JSON
                         Data.Avro.Schema
+                        Data.Avro.Schema.Deconflict
                         Data.Avro.ToAvro
                         Data.Avro.Types
                         Data.Avro.Types.Value

--- a/avro.cabal
+++ b/avro.cabal
@@ -202,6 +202,8 @@ test-suite test
                         Avro.Deconflict.B.Writer
                         Avro.Deconflict.C.Reader
                         Avro.Deconflict.C.Writer
+                        Avro.Deconflict.D.Reader
+                        Avro.Deconflict.D.Writer
                         Avro.DeconflictSpec
                         Avro.DefaultsSpec
                         Avro.EncodeRawSpec

--- a/bench/Bench/Time.hs
+++ b/bench/Bench/Time.hs
@@ -60,9 +60,9 @@ encodeArray = env randoms $ \ ~(bools, ints, longs, records) ->
           , ("l", Value.Long long)
           ]
         recordSchema = Schema.Record "Rec" [] Nothing Nothing
-          [ Schema.Field "b" [] Nothing Nothing Schema.Boolean Nothing
-          , Schema.Field "i" [] Nothing Nothing Schema.Int Nothing
-          , Schema.Field "l" [] Nothing Nothing Schema.Long Nothing
+          [ Schema.Field "b" [] Nothing Nothing Schema.AsIs Schema.Boolean Nothing
+          , Schema.Field "i" [] Nothing Nothing Schema.AsIs Schema.Int Nothing
+          , Schema.Field "l" [] Nothing Nothing Schema.AsIs Schema.Long Nothing
           ]
 
 encodeAvro :: Value Schema -> LBS.ByteString
@@ -106,9 +106,9 @@ decodeArray = env randoms $ \ ~(bools, ints, longs, records) ->
           , ("l", Value.Long long)
           ]
         recordSchema = Schema.Record "Rec" [] Nothing Nothing
-          [ Schema.Field "b" [] Nothing Nothing Schema.Boolean Nothing
-          , Schema.Field "i" [] Nothing Nothing Schema.Int Nothing
-          , Schema.Field "l" [] Nothing Nothing Schema.Long Nothing
+          [ Schema.Field "b" [] Nothing Nothing Schema.AsIs Schema.Boolean Nothing
+          , Schema.Field "i" [] Nothing Nothing Schema.AsIs Schema.Int Nothing
+          , Schema.Field "l" [] Nothing Nothing Schema.AsIs Schema.Long Nothing
           ]
 
 decodeAvro :: Schema -> LBS.ByteString -> Value Schema

--- a/bench/Bench/Time.hs
+++ b/bench/Bench/Time.hs
@@ -60,9 +60,9 @@ encodeArray = env randoms $ \ ~(bools, ints, longs, records) ->
           , ("l", Value.Long long)
           ]
         recordSchema = Schema.Record "Rec" [] Nothing Nothing
-          [ Schema.Field "b" [] Nothing Nothing Schema.AsIs Schema.Boolean Nothing
-          , Schema.Field "i" [] Nothing Nothing Schema.AsIs Schema.Int Nothing
-          , Schema.Field "l" [] Nothing Nothing Schema.AsIs Schema.Long Nothing
+          [ Schema.Field "b" [] Nothing Nothing False Schema.Boolean Nothing
+          , Schema.Field "i" [] Nothing Nothing False Schema.Int Nothing
+          , Schema.Field "l" [] Nothing Nothing False Schema.Long Nothing
           ]
 
 encodeAvro :: Value Schema -> LBS.ByteString
@@ -106,9 +106,9 @@ decodeArray = env randoms $ \ ~(bools, ints, longs, records) ->
           , ("l", Value.Long long)
           ]
         recordSchema = Schema.Record "Rec" [] Nothing Nothing
-          [ Schema.Field "b" [] Nothing Nothing Schema.AsIs Schema.Boolean Nothing
-          , Schema.Field "i" [] Nothing Nothing Schema.AsIs Schema.Int Nothing
-          , Schema.Field "l" [] Nothing Nothing Schema.AsIs Schema.Long Nothing
+          [ Schema.Field "b" [] Nothing Nothing False Schema.Boolean Nothing
+          , Schema.Field "i" [] Nothing Nothing False Schema.Int Nothing
+          , Schema.Field "l" [] Nothing Nothing False Schema.Long Nothing
           ]
 
 decodeAvro :: Schema -> LBS.ByteString -> Value Schema

--- a/src/Data/Avro.hs
+++ b/src/Data/Avro.hs
@@ -129,7 +129,7 @@ decodeContainer bs =
 -- allow this function to be read lazy (to be done in some later version).
 decodeContainerWithSchema :: FromAvro a => Schema -> ByteString -> [[a]]
 decodeContainerWithSchema readerSchema bs =
-  case D.decodeContainerWith (D.getAvroOf . flip deconflict readerSchema) bs of
+  case D.decodeContainerWith (either fail D.getAvroOf . flip deconflict readerSchema) bs of
     Right (_, val) ->
       let
         from v = case fromAvro v of

--- a/src/Data/Avro.hs
+++ b/src/Data/Avro.hs
@@ -131,11 +131,9 @@ decodeContainerWithSchema readerSchema bs =
   case D.decodeContainer bs of
     Right (writerSchema,val) ->
       let
-        writerSchema' = S.expandNamedTypes writerSchema
-        readerSchema' = S.expandNamedTypes readerSchema
         err e = error $ "Could not deconflict reader and writer schema." <> e
         dec x =
-          case C.deconflictNoResolve writerSchema' readerSchema' x of
+          case C.deconflict writerSchema readerSchema x of
             Left e   -> err e
             Right v  -> case fromAvro v of
                           Success x -> x

--- a/src/Data/Avro/Decode/Lazy.hs
+++ b/src/Data/Avro/Decode/Lazy.hs
@@ -129,7 +129,7 @@ decodeContainerWithSchema' readerSchema bs = do
   pure $ (fmap . fmap) (resultToEither . fromLazyAvro) vals
   where
     getDeconflictedValues = getContainerValuesWith (getAvroOf' . flip deconflict readerSchema)
-    getAvroOf' :: Either String Schema -> BL.ByteString -> (BL.ByteString, T.LazyValue Type)
+    getAvroOf' :: Either String Schema -> BL.ByteString -> (BL.ByteString, T.LazyValue Schema)
     getAvroOf' (Left err) bs = (bs, T.Error err)
     getAvroOf' (Right sc) bs = getAvroOf sc bs
 
@@ -344,7 +344,7 @@ getAvroOf ty0 bs = go ty0 bs
       FloatDoubleCoercion -> decodeGet @Float (T.Double . realToFrac)   bs
       FreeUnion {..} -> T.Union (V.singleton ty) ty <$> go ty bs
 
-  getField :: Field -> BL.ByteString -> (BL.ByteString, Maybe (Text, T.LazyValue Type))
+  getField :: Field -> BL.ByteString -> (BL.ByteString, Maybe (Text, T.LazyValue Schema))
   getField Field{..} bs =
     case (fldReadIgnore, fldDefault) of
       (False, _)       -> Just . (fldName,) <$> go fldType bs

--- a/src/Data/Avro/Decode/Lazy.hs
+++ b/src/Data/Avro/Decode/Lazy.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections       #-}
+{-# LANGUAGE TypeApplications    #-}
 
 module Data.Avro.Decode.Lazy
   ( decodeAvro
@@ -66,8 +67,8 @@ import           Data.Avro.Zag
 import qualified Data.Avro.Decode.Strict.Internal as DecodeStrict
 
 import Data.Avro.Decode.Get
-import Data.Avro.Decode.Lazy.Convert      (toStrictValue)
-import Data.Avro.Decode.Lazy.Deconflict   as C
+import Data.Avro.Decode.Lazy.Convert      (fromStrictValue, toStrictValue)
+import Data.Avro.Schema.Deconflict   as Dec
 import Data.Avro.Decode.Lazy.FromLazyAvro
 import Data.Avro.FromAvro
 
@@ -124,10 +125,10 @@ decodeContainerWithSchema s bs =
 -- and with the container's writer schema.
 decodeContainerWithSchema' :: FromLazyAvro a => Schema -> BL.ByteString -> Either String [[Either String a]]
 decodeContainerWithSchema' readerSchema bs = do
-  (writerSchema, vals) <- getContainerValues bs
-  pure $ (fmap . fmap) (convertValue writerSchema readerSchema) vals
+  (_, vals) <- getDeconflictedValues bs
+  pure $ (fmap . fmap) (resultToEither . fromLazyAvro) vals
   where
-    convertValue w r v = resultToEither $ fromLazyAvro (C.deconflict w r v)
+    getDeconflictedValues = getContainerValuesWith (getAvroOf . flip deconflict readerSchema)
 
 -- |Decode bytes into a 'Value' as described by Schema.
 decodeAvro :: Schema -> BL.ByteString -> T.LazyValue Schema
@@ -308,9 +309,8 @@ getAvroOf ty0 bs = go ty0 bs
           Right (bs', _, v)  -> go v bs'
 
       Record {..} -> do
-        let getField bs' Field {..} = (fldName,) <$> go fldType bs'
-        let flds = foldl' (\(bs', as) fld -> (:as) <$> getField bs' fld ) (bs, []) fields
-        T.Record ty . HashMap.fromList <$> flds
+        let flds = foldl' (\(bs', as) fld -> (:as) <$> getField fld bs' ) (bs, []) fields
+        T.Record ty . HashMap.fromList . catMaybes <$> flds
 
       Enum {..} ->
         case runGetOrFail getLong bs of
@@ -332,6 +332,22 @@ getAvroOf ty0 bs = go ty0 bs
         case runGetOrFail (G.getByteString (fromIntegral size)) bs of
           Left (bs', _, err) -> (bs', T.Error err)
           Right (bs', _, v)  -> (bs', T.Fixed ty v)
+
+      IntLongCoercion     -> decodeGet @Int32 (T.Long   . fromIntegral) bs
+      IntFloatCoercion    -> decodeGet @Int32 (T.Float  . fromIntegral) bs
+      IntDoubleCoercion   -> decodeGet @Int32 (T.Double . fromIntegral) bs
+      LongFloatCoercion   -> decodeGet @Int64 (T.Float  . fromIntegral) bs
+      LongDoubleCoercion  -> decodeGet @Int64 (T.Double . fromIntegral) bs
+      FloatDoubleCoercion -> decodeGet @Float (T.Double . realToFrac)   bs
+      FreeUnion {..} -> T.Union (V.singleton ty) ty <$> go ty bs
+      Panic {..} -> (fst (go ty bs), T.Error err)
+
+  getField :: Field -> BL.ByteString -> (BL.ByteString, Maybe (Text, T.LazyValue Type))
+  getField Field{..} bs =
+    case fldStatus of
+      AsIs        -> Just . (fldName,) <$> go fldType bs
+      Ignored     -> (fst (go fldType bs), Nothing)
+      Defaulted v -> (bs, Just (fldName, fromStrictValue v))
 {-# INLINABLE getAvroOf #-}
 
 getKVPair getElement bs =

--- a/src/Data/Avro/Decode/Lazy.hs
+++ b/src/Data/Avro/Decode/Lazy.hs
@@ -125,11 +125,9 @@ decodeContainerWithSchema s bs =
 decodeContainerWithSchema' :: FromLazyAvro a => Schema -> BL.ByteString -> Either String [[Either String a]]
 decodeContainerWithSchema' readerSchema bs = do
   (writerSchema, vals) <- getContainerValues bs
-  let writerSchema' = S.expandNamedTypes writerSchema
-  let readerSchema' = S.expandNamedTypes readerSchema
-  pure $ (fmap . fmap) (convertValue writerSchema' readerSchema') vals
+  pure $ (fmap . fmap) (convertValue writerSchema readerSchema) vals
   where
-    convertValue w r v = resultToEither $ fromLazyAvro (C.deconflictNoResolve w r v)
+    convertValue w r v = resultToEither $ fromLazyAvro (C.deconflict w r v)
 
 -- |Decode bytes into a 'Value' as described by Schema.
 decodeAvro :: Schema -> BL.ByteString -> T.LazyValue Schema

--- a/src/Data/Avro/Decode/Lazy.hs
+++ b/src/Data/Avro/Decode/Lazy.hs
@@ -346,10 +346,10 @@ getAvroOf ty0 bs = go ty0 bs
 
   getField :: Field -> BL.ByteString -> (BL.ByteString, Maybe (Text, T.LazyValue Type))
   getField Field{..} bs =
-    case fldStatus of
-      AsIs        -> Just . (fldName,) <$> go fldType bs
-      Ignored     -> (fst (go fldType bs), Nothing)
-      Defaulted v -> (bs, Just (fldName, fromStrictValue v))
+    case (fldReadIgnore, fldDefault) of
+      (False, _)       -> Just . (fldName,) <$> go fldType bs
+      (True,  Just v)  -> (bs, Just (fldName, fromStrictValue v))
+      (True,  Nothing) -> (fst (go fldType bs), Nothing)
 {-# INLINABLE getAvroOf #-}
 
 getKVPair getElement bs =

--- a/src/Data/Avro/Decode/Lazy/Deconflict.hs
+++ b/src/Data/Avro/Decode/Lazy/Deconflict.hs
@@ -22,6 +22,12 @@ import qualified Data.Text.Encoding              as Text
 import           Data.Vector                     (Vector)
 import qualified Data.Vector                     as V
 
+type Deconflicter =
+     Schema        -- ^ Writer schema
+  -> Schema        -- ^ Reader schema
+  -> T.LazyValue Schema
+  -> T.LazyValue Schema
+
 -- | @deconflict writer reader val@ will convert a value that was
 -- encoded/decoded with the writer's schema into the form specified by the
 -- reader's schema.
@@ -33,8 +39,7 @@ deconflict :: Schema        -- ^ Writer schema
            -> Schema        -- ^ Reader schema
            -> T.LazyValue Schema
            -> T.LazyValue Schema
-deconflict writerSchema readerSchema =
-  deconflictNoResolve (S.expandNamedTypes writerSchema) (S.expandNamedTypes readerSchema)
+deconflict = startDeconflict True
 
 -- | @deconflict writer reader val@ will convert a value that was
 -- encoded/decoded with the writer's schema into the form specified by the
@@ -50,15 +55,16 @@ deconflictNoResolve :: Schema         -- ^ Writer schema
                     -> Schema         -- ^ Reader schema
                     -> T.LazyValue Schema
                     -> T.LazyValue Schema
-deconflictNoResolve writerSchema readerSchema =
-  deconflictValue writerSchema readerSchema
+deconflictNoResolve = startDeconflict False
 
-deconflictValue :: Schema -> Schema -> T.LazyValue Schema -> T.LazyValue Schema
-deconflictValue writerSchema readerSchema v
-  | writerSchema == readerSchema    = v
-  | otherwise = go writerSchema readerSchema v
+startDeconflict :: Bool -> Deconflicter
+startDeconflict shouldExpandNames writerSchema readerSchema = go writerSchema readerSchema
   where
-    go :: Schema -> Schema -> T.LazyValue Schema -> T.LazyValue Schema
+    aEnv = S.buildTypeEnvironment (const $ Left "Bad Schema") writerSchema
+    bEnv = S.buildTypeEnvironment (const $ Left "Bad Schema") readerSchema
+    go :: Deconflicter
+    go aTy bTy val
+        | not shouldExpandNames && aTy == bTy = val
     go _ _ val@(T.Error _) = val
     go (S.Array aTy) (S.Array bTy) (T.Array vec) =
         T.Array $ fmap (go aTy bTy) vec
@@ -69,22 +75,27 @@ deconflictValue writerSchema readerSchema v
     go a@S.Fixed {} b@S.Fixed {} val
         | name a == name b && size a == size b = val
     go a@S.Record {} b@S.Record {} val
-        | name a == name b = deconflictRecord a b val
+        | name a == name b = deconflictRecord go a b val
     go (S.Union xs) (S.Union ys) (T.Union _ tyVal val) =
-        withSchemaIn tyVal xs $ \sch -> deconflictReaderUnion sch ys val
+        withSchemaIn tyVal xs $ \sch -> deconflictReaderUnion go sch ys val
     go nonUnion (S.Union ys) val =
-        deconflictReaderUnion nonUnion ys val
+        deconflictReaderUnion go nonUnion ys val
     go (S.Union xs) nonUnion (T.Union _ tyVal val) =
-        withSchemaIn tyVal xs $ \sch -> deconflictValue sch nonUnion val
+        withSchemaIn tyVal xs $ \sch -> go sch nonUnion val
+    go (S.NamedType t) bTy val =
+      either T.Error (\aTy -> go aTy bTy val) $ aEnv t
+    go aTy (S.NamedType t) val =
+      either T.Error (\bTy -> go aTy bTy val) $ bEnv t
+    go aTy bTy val | aTy == bTy = val
     go eTy dTy val =
       case val of
         T.Int i32  | dTy == S.Long   -> T.Long   (fromIntegral i32)
                    | dTy == S.Float  -> T.Float  (fromIntegral i32)
                    | dTy == S.Double -> T.Double (fromIntegral i32)
-        T.Long i64 | dTy == S.Float  -> T.Float (fromIntegral i64)
+        T.Long i64 | dTy == S.Float  -> T.Float  (fromIntegral i64)
                    | dTy == S.Double -> T.Double (fromIntegral i64)
         T.Float f  | dTy == S.Double -> T.Double (realToFrac f)
-        T.String s | dTy == S.Bytes  -> T.Bytes (Text.encodeUtf8 s)
+        T.String s | dTy == S.Bytes  -> T.Bytes  (Text.encodeUtf8 s)
         T.Bytes bs | dTy == S.String -> T.String (Text.decodeUtf8 bs)
         _                            -> T.Error $ "Can not resolve differing writer and reader schemas: " ++ show (eTy, dTy)
 
@@ -104,32 +115,32 @@ withSchemaIn schema schemas f =
     Nothing    -> T.Error $ "Incorrect payload: union " <> (show . Foldable.toList $ typeName <$> schemas) <> " does not contain schema " <> Text.unpack (typeName schema)
     Just found -> f found
 
-deconflictReaderUnion :: Schema -> Vector Schema -> T.LazyValue Schema -> T.LazyValue Schema
-deconflictReaderUnion valueType unionTypes val =
+deconflictReaderUnion :: Deconflicter -> Schema -> Vector Schema -> T.LazyValue Schema -> T.LazyValue Schema
+deconflictReaderUnion go valueType unionTypes val =
   let hdl [] = T.Error $ "No corresponding union value for " <> Text.unpack (typeName valueType)
       hdl (d:rest) =
-            case deconflictValue valueType d val of
+            case go valueType d val of
               T.Error _ -> hdl rest
               v         -> T.Union unionTypes d v
   in hdl (V.toList unionTypes)
 
-deconflictRecord :: Schema -> Schema -> T.LazyValue Schema -> T.LazyValue Schema
-deconflictRecord writerSchema readerSchema (T.Record ty fldVals)  =
-  T.Record readerSchema . HashMap.fromList $ fmap (deconflictFields fldVals (fields writerSchema)) (fields readerSchema)
+deconflictRecord :: Deconflicter -> Schema -> Schema -> T.LazyValue Schema -> T.LazyValue Schema
+deconflictRecord go writerSchema readerSchema (T.Record ty fldVals)  =
+  T.Record readerSchema . HashMap.fromList $ fmap (deconflictFields go fldVals (fields writerSchema)) (fields readerSchema)
 
 -- For each field of the decoders, lookup the field in the hash map
---  1) If the field exists, call 'deconflictValue'
+--  1) If the field exists, call the given deconflicting function
 --  2) If the field is missing use the reader's default
 --  3) If there is no default, fail.
 --
 -- XXX: Consider aliases in the writer schema, use those to retry on failed lookup.
-deconflictFields :: HashMap Text (T.LazyValue Schema) -> [Field] -> Field -> (Text,T.LazyValue Schema)
-deconflictFields hm writerFields readerField =
+deconflictFields :: Deconflicter -> HashMap Text (T.LazyValue Schema) -> [Field] -> Field -> (Text,T.LazyValue Schema)
+deconflictFields go hm writerFields readerField =
   let
     mbWriterField = findField readerField writerFields
     mbValue = HashMap.lookup (fldName readerField) hm
   in case (mbWriterField, mbValue, fldDefault readerField) of
-    (Just w, Just x,_)  -> (fldName readerField, deconflictValue (fldType w) (fldType readerField) x)
+    (Just w, Just x,_)  -> (fldName readerField, go (fldType w) (fldType readerField) x)
     (_, Just x,_)       -> (fldName readerField, x)
     (_, _,Just def)     -> (fldName readerField, fromStrictValue def)
     (_,Nothing,Nothing) -> (fldName readerField, T.Error ("No field and no default for " ++ show (fldName readerField)))

--- a/src/Data/Avro/Decode/Lazy/Deconflict.hs
+++ b/src/Data/Avro/Decode/Lazy/Deconflict.hs
@@ -22,6 +22,8 @@ import qualified Data.Text.Encoding              as Text
 import           Data.Vector                     (Vector)
 import qualified Data.Vector                     as V
 
+{-# DEPRECATED deconflict, deconflictNoResolve "Use Data.Avro.Schema.Deconflict.deconflict or Data.Avro.Decode.Lazy.decodeContainerWithSchema instead." #-}
+
 type Deconflicter =
      Schema        -- ^ Writer schema
   -> Schema        -- ^ Reader schema

--- a/src/Data/Avro/Decode/Strict/Internal.hs
+++ b/src/Data/Avro/Decode/Strict/Internal.hs
@@ -83,7 +83,6 @@ getAvroOf ty0 = go ty0
     LongDoubleCoercion  -> T.Double . fromIntegral <$> getAvro @Int64
     FloatDoubleCoercion -> T.Double . realToFrac   <$> getAvro @Float
     FreeUnion ty -> T.Union (V.singleton ty) ty <$> go ty
-    Panic {..} -> fail err
 
  getField :: Field -> Get (Maybe (Text, T.Value Type))
  getField Field{..} =

--- a/src/Data/Avro/Decode/Strict/Internal.hs
+++ b/src/Data/Avro/Decode/Strict/Internal.hs
@@ -84,7 +84,7 @@ getAvroOf ty0 = go ty0
     FloatDoubleCoercion -> T.Double . realToFrac   <$> getAvro @Float
     FreeUnion ty -> T.Union (V.singleton ty) ty <$> go ty
 
- getField :: Field -> Get (Maybe (Text, T.Value Type))
+ getField :: Field -> Get (Maybe (Text, T.Value Schema))
  getField Field{..} =
   case (fldReadIgnore, fldDefault) of
     (False, _)       -> Just . (fldName,) <$> go fldType

--- a/src/Data/Avro/Decode/Strict/Internal.hs
+++ b/src/Data/Avro/Decode/Strict/Internal.hs
@@ -86,10 +86,10 @@ getAvroOf ty0 = go ty0
 
  getField :: Field -> Get (Maybe (Text, T.Value Type))
  getField Field{..} =
-  case fldStatus of
-    AsIs        -> Just . (fldName,) <$> go fldType
-    Ignored     -> go fldType >> pure Nothing
-    Defaulted v -> pure $ Just (fldName, v)
+  case (fldReadIgnore, fldDefault) of
+    (False, _)       -> Just . (fldName,) <$> go fldType
+    (True,  Just v)  -> pure $ Just (fldName, v)
+    (True,  Nothing) -> go fldType >> pure Nothing
 
  getKVBlocks :: Schema -> Get [[(Text,T.Value Schema)]]
  getKVBlocks t =

--- a/src/Data/Avro/Decode/Strict/Internal.hs
+++ b/src/Data/Avro/Decode/Strict/Internal.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections       #-}
+{-# LANGUAGE TypeApplications    #-}
 module Data.Avro.Decode.Strict.Internal
 where
 
@@ -64,8 +65,7 @@ getAvroOf ty0 = go ty0
          return $ T.Map (HashMap.fromList $ mconcat kvs)
     NamedType tn -> env tn >>= go
     Record {..} ->
-      do let getField Field {..} = (fldName,) <$> go fldType
-         T.Record ty . HashMap.fromList <$> mapM getField fields
+      T.Record ty . HashMap.fromList . catMaybes <$> mapM getField fields
     Enum {..} ->
       do i <- getLong
          let sym = fromMaybe "" (symbols V.!? (fromIntegral i)) -- empty string for 'missing' symbols (alternative is an error or exception)
@@ -76,6 +76,21 @@ getAvroOf ty0 = go ty0
           Nothing -> fail $ "Decoded Avro tag is outside the expected range for a Union. Tag: " <> show i <> " union of: " <> show (V.map typeName ts)
           Just t  -> T.Union ts t <$> go t
     Fixed {..} -> T.Fixed ty <$> G.getByteString (fromIntegral size)
+    IntLongCoercion     -> T.Long   . fromIntegral <$> getAvro @Int32
+    IntFloatCoercion    -> T.Float  . fromIntegral <$> getAvro @Int32
+    IntDoubleCoercion   -> T.Double . fromIntegral <$> getAvro @Int32
+    LongFloatCoercion   -> T.Float  . fromIntegral <$> getAvro @Int64
+    LongDoubleCoercion  -> T.Double . fromIntegral <$> getAvro @Int64
+    FloatDoubleCoercion -> T.Double . realToFrac   <$> getAvro @Float
+    FreeUnion ty -> T.Union (V.singleton ty) ty <$> go ty
+    Panic {..} -> fail err
+
+ getField :: Field -> Get (Maybe (Text, T.Value Type))
+ getField Field{..} =
+  case fldStatus of
+    AsIs        -> Just . (fldName,) <$> go fldType
+    Ignored     -> go fldType >> pure Nothing
+    Defaulted v -> pure $ Just (fldName, v)
 
  getKVBlocks :: Schema -> Get [[(Text,T.Value Schema)]]
  getKVBlocks t =

--- a/src/Data/Avro/Deconflict.hs
+++ b/src/Data/Avro/Deconflict.hs
@@ -22,6 +22,8 @@ import qualified Data.Text.Encoding  as Text
 import           Data.Vector         (Vector)
 import qualified Data.Vector         as V
 
+{-# DEPRECATED deconflict, deconflictNoResolve "Use Data.Avro.Schema.Deconflict.deconflict or Data.Avro.decodeContainerWithSchema instead." #-}
+
 type Deconflicter =
      Schema        -- ^ Writer schema
   -> Schema        -- ^ Reader schema

--- a/src/Data/Avro/Deconflict.hs
+++ b/src/Data/Avro/Deconflict.hs
@@ -22,6 +22,12 @@ import qualified Data.Text.Encoding  as Text
 import           Data.Vector         (Vector)
 import qualified Data.Vector         as V
 
+type Deconflicter =
+     Schema        -- ^ Writer schema
+  -> Schema        -- ^ Reader schema
+  -> T.Value Schema
+  -> Either String (T.Value Schema)
+
 -- | @deconflict writer reader val@ will convert a value that was
 -- encoded/decoded with the writer's schema into the form specified by the
 -- reader's schema.
@@ -33,8 +39,7 @@ deconflict :: Schema        -- ^ Writer schema
            -> Schema        -- ^ Reader schema
            -> T.Value Schema
            -> Either String (T.Value Schema)
-deconflict writerSchema readerSchema =
-  deconflictNoResolve (S.expandNamedTypes writerSchema) (S.expandNamedTypes readerSchema)
+deconflict = startDeconflict True
 
 -- | @deconflict writer reader val@ will convert a value that was
 -- encoded/decoded with the writer's schema into the form specified by the
@@ -50,18 +55,17 @@ deconflictNoResolve :: Schema         -- ^ Writer schema
                     -> Schema         -- ^ Reader schema
                     -> T.Value Schema
                     -> Either String (T.Value Schema)
-deconflictNoResolve writerSchema readerSchema =
-  deconflictValue writerSchema readerSchema
+deconflictNoResolve = startDeconflict False
 
-deconflictValue :: Schema
-              -> Schema
-              -> T.Value Schema
-              -> Either String (T.Value Schema)
-deconflictValue writerSchema readerSchema v
-  | writerSchema == readerSchema    = Right v
-  | otherwise = go writerSchema readerSchema v
+
+startDeconflict :: Bool -> Deconflicter
+startDeconflict shouldExpandNames writerSchema readerSchema = go writerSchema readerSchema
   where
-  go :: Schema -> Schema -> T.Value Schema -> Either String (T.Value Schema)
+  aEnv = S.buildTypeEnvironment (const $ Left "Bad Schema") writerSchema
+  bEnv = S.buildTypeEnvironment (const $ Left "Bad Schema") readerSchema
+  go :: Deconflicter
+  go aTy bTy val
+    | not shouldExpandNames && aTy == bTy = Right val
   go (S.Array aTy) (S.Array bTy) (T.Array vec) =
        T.Array <$> mapM (go aTy bTy) vec
   go (S.Map aTy) (S.Map bTy) (T.Map mp)    =
@@ -71,22 +75,29 @@ deconflictValue writerSchema readerSchema v
   go a@S.Fixed {} b@S.Fixed {} val
        | name a == name b && size a == size b = Right val
   go a@S.Record {} b@S.Record {} val
-       | name a == name b = deconflictRecord a b val
+       | name a == name b = deconflictRecord go a b val
   go (S.Union xs) (S.Union ys) (T.Union _ tyVal val) =
-       withSchemaIn tyVal xs $ \sch -> deconflictReaderUnion sch ys val
+       withSchemaIn tyVal xs $ \sch -> deconflictReaderUnion go sch ys val
   go nonUnion (S.Union ys) val =
-       deconflictReaderUnion nonUnion ys val
+       deconflictReaderUnion go nonUnion ys val
   go (S.Union xs) nonUnion (T.Union _ tyVal val) =
-       withSchemaIn tyVal xs $ \sch -> deconflictValue sch nonUnion val
+       withSchemaIn tyVal xs $ \sch -> go sch nonUnion val
+  go (S.NamedType t) bTy val = do
+       aTy <- aEnv t
+       go aTy bTy val
+  go aTy (S.NamedType t) val = do
+       bTy <- bEnv t
+       go aTy bTy val
+  go aTy bTy val | aTy == bTy = Right val
   go eTy dTy val =
     case val of
       T.Int i32  | dTy == S.Long   -> Right $ T.Long   (fromIntegral i32)
                  | dTy == S.Float  -> Right $ T.Float  (fromIntegral i32)
                  | dTy == S.Double -> Right $ T.Double (fromIntegral i32)
-      T.Long i64 | dTy == S.Float  -> Right $ T.Float (fromIntegral i64)
+      T.Long i64 | dTy == S.Float  -> Right $ T.Float  (fromIntegral i64)
                  | dTy == S.Double -> Right $ T.Double (fromIntegral i64)
       T.Float f  | dTy == S.Double -> Right $ T.Double (realToFrac f)
-      T.String s | dTy == S.Bytes  -> Right $ T.Bytes (Text.encodeUtf8 s)
+      T.String s | dTy == S.Bytes  -> Right $ T.Bytes  (Text.encodeUtf8 s)
       T.Bytes bs | dTy == S.String -> Right $ T.String (Text.decodeUtf8 bs)
       _                            -> Left $ "Can not resolve differing writer and reader schemas: " ++ show (eTy, dTy)
 
@@ -106,32 +117,32 @@ withSchemaIn schema schemas f =
     Nothing    -> Left $ "Incorrect payload: union " <> (show . Foldable.toList $ typeName <$> schemas) <> " does not contain schema " <> Text.unpack (typeName schema)
     Just found -> f found
 
-deconflictReaderUnion :: Schema -> Vector Schema -> T.Value Schema -> Either String (T.Value Schema)
-deconflictReaderUnion valueSchema unionTypes val =
+deconflictReaderUnion :: Deconflicter -> Schema -> Vector Schema -> T.Value Schema -> Either String (T.Value Schema)
+deconflictReaderUnion go valueSchema unionTypes val =
     let hdl [] = Left "Impossible: empty non-empty list."
         hdl (d:rest) =
-              case deconflictValue valueSchema d val of
+              case go valueSchema d val of
                 Right v -> Right (T.Union unionTypes d v)
                 Left _  -> hdl rest
     in hdl (V.toList unionTypes)
 
-deconflictRecord :: Schema -> Schema -> T.Value Schema -> Either String (T.Value Schema)
-deconflictRecord writerSchema readerSchema (T.Record ty fldVals)  =
-  T.Record readerSchema . HashMap.fromList <$> mapM (deconflictFields fldVals (fields writerSchema)) (fields readerSchema)
+deconflictRecord :: Deconflicter -> Schema -> Schema -> T.Value Schema -> Either String (T.Value Schema)
+deconflictRecord go writerSchema readerSchema (T.Record ty fldVals)  =
+  T.Record readerSchema . HashMap.fromList <$> mapM (deconflictFields go fldVals (fields writerSchema)) (fields readerSchema)
 
 -- For each field of the decoders, lookup the field in the hash map
---  1) If the field exists, call 'deconflictValue'
+--  1) If the field exists, call the given deconflicting function
 --  2) If the field is missing use the reader's default
 --  3) If there is no default, fail.
 --
 -- XXX: Consider aliases in the writer schema, use those to retry on failed lookup.
-deconflictFields :: HashMap Text (T.Value Schema) -> [Field] -> Field -> Either String (Text,T.Value Schema)
-deconflictFields hm writerFields readerField =
+deconflictFields :: Deconflicter -> HashMap Text (T.Value Schema) -> [Field] -> Field -> Either String (Text,T.Value Schema)
+deconflictFields go hm writerFields readerField =
   let
     mbWriterField = findField readerField writerFields
     mbValue = HashMap.lookup (fldName readerField) hm
   in case (mbWriterField, mbValue, fldDefault readerField) of
-    (Just w, Just x,_)  -> (fldName readerField,) <$> deconflictValue (fldType w) (fldType readerField) x
+    (Just w, Just x,_)  -> (fldName readerField,) <$> go (fldType w) (fldType readerField) x
     (_, Just x,_)       -> Right (fldName readerField, x)
     (_, _,Just def)     -> Right (fldName readerField, def)
     (_,Nothing,Nothing) -> Left $ "No field and no default for " ++ show (fldName readerField)

--- a/src/Data/Avro/Deriving/Lift.hs
+++ b/src/Data/Avro/Deriving/Lift.hs
@@ -35,4 +35,3 @@ deriving instance Lift Schema.Field
 deriving instance Lift Schema.Order
 deriving instance Lift Schema.TypeName
 deriving instance Lift Schema.Schema
-deriving instance Lift Schema.FieldStatus

--- a/src/Data/Avro/Deriving/Lift.hs
+++ b/src/Data/Avro/Deriving/Lift.hs
@@ -35,3 +35,4 @@ deriving instance Lift Schema.Field
 deriving instance Lift Schema.Order
 deriving instance Lift Schema.TypeName
 deriving instance Lift Schema.Schema
+deriving instance Lift Schema.FieldStatus

--- a/src/Data/Avro/Schema.hs
+++ b/src/Data/Avro/Schema.hs
@@ -27,7 +27,6 @@ module Data.Avro.Schema
   , parseFullname
   , mkEnum, mkUnion
   , validateSchema
-  , isSchemaStrict
   -- * Lower level utilities
   , typeName
   , buildTypeEnvironment
@@ -126,7 +125,6 @@ data Schema
       | LongDoubleCoercion
       | FloatDoubleCoercion
       | FreeUnion { ty :: Type }
-      | Panic { ty :: Type, err :: String }
     deriving (Show, Generic, NFData)
 
 instance Eq Schema where
@@ -158,7 +156,6 @@ instance Eq Schema where
   LongDoubleCoercion  == LongDoubleCoercion  = True
   FloatDoubleCoercion == FloatDoubleCoercion = True
   FreeUnion ty1 == FreeUnion ty2 = ty1 == ty2
-  Panic ty1 _ == Panic ty2 _ = ty1 == ty2
 
   _ == _ = False
 
@@ -711,16 +708,6 @@ instance FromJSON Order where
 --  * Named types are resolvable
 validateSchema :: Schema -> Parser ()
 validateSchema _sch = return () -- XXX TODO
-
--- | True iff there are no errors in the schema.
-isSchemaStrict :: Schema -> Bool
-isSchemaStrict Array{item}    = isSchemaStrict item
-isSchemaStrict Map{values}    = isSchemaStrict values
-isSchemaStrict Record{fields} = all (isSchemaStrict . fldType) fields
-isSchemaStrict Union{options} = V.all isSchemaStrict options
-isSchemaStrict FreeUnion{ty}  = isSchemaStrict ty
-isSchemaStrict Panic{}        = False
-isSchemaStrict _              = True
 
 -- | @buildTypeEnvironment schema@ builds a function mapping type names to
 -- the types declared in the traversed schema.

--- a/src/Data/Avro/Schema.hs
+++ b/src/Data/Avro/Schema.hs
@@ -21,7 +21,7 @@ module Data.Avro.Schema
   (
    -- * Schema description types
     Schema(..), Type
-  , Field(..), Order(..), FieldStatus(..)
+  , Field(..), Order(..)
   , TypeName(..)
   , renderFullname
   , parseFullname
@@ -304,19 +304,13 @@ typeName bt =
     Union ts       -> typeName (V.head ts)
     _              -> renderFullname $ name bt
 
-data FieldStatus =
-    AsIs
-  | Ignored
-  | Defaulted (Ty.Value Schema)
-  deriving (Eq, Show, Generic, NFData)
-
-data Field = Field { fldName    :: Text
-                   , fldAliases :: [Text]
-                   , fldDoc     :: Maybe Text
-                   , fldOrder   :: Maybe Order
-                   , fldStatus  :: FieldStatus
-                   , fldType    :: Schema
-                   , fldDefault :: Maybe (Ty.Value Schema)
+data Field = Field { fldName       :: Text
+                   , fldAliases    :: [Text]
+                   , fldDoc        :: Maybe Text
+                   , fldOrder      :: Maybe Order
+                   , fldReadIgnore :: Bool
+                   , fldType       :: Schema
+                   , fldDefault    :: Maybe (Ty.Value Schema)
                    }
   deriving (Eq, Show, Generic, NFData)
 
@@ -431,7 +425,7 @@ parseField record = \case
 
     let mkAlias name = mkTypeName (Just record) name Nothing
     aliases  <- o .:? "aliases"  .!= []
-    return $ Field name aliases doc order AsIs ty def
+    return $ Field name aliases doc order False ty def
   invalid    -> typeMismatch "Field" invalid
 
 instance ToJSON Schema where

--- a/src/Data/Avro/Schema.hs
+++ b/src/Data/Avro/Schema.hs
@@ -21,12 +21,13 @@ module Data.Avro.Schema
   (
    -- * Schema description types
     Schema(..), Type
-  , Field(..), Order(..)
+  , Field(..), Order(..), FieldStatus(..)
   , TypeName(..)
   , renderFullname
   , parseFullname
   , mkEnum, mkUnion
   , validateSchema
+  , isSchemaStrict
   -- * Lower level utilities
   , typeName
   , buildTypeEnvironment
@@ -118,6 +119,14 @@ data Schema
               , aliases :: [TypeName]
               , size    :: Int
               }
+      | IntLongCoercion
+      | IntFloatCoercion
+      | IntDoubleCoercion
+      | LongFloatCoercion
+      | LongDoubleCoercion
+      | FloatDoubleCoercion
+      | FreeUnion { ty :: Type }
+      | Panic { ty :: Type, err :: String }
     deriving (Show, Generic, NFData)
 
 instance Eq Schema where
@@ -141,6 +150,15 @@ instance Eq Schema where
   Union a == Union b = a == b
   Fixed name1 _ s == Fixed name2 _ s2 =
     and [name1 == name2, s == s2]
+
+  IntLongCoercion     == IntLongCoercion     = True
+  IntFloatCoercion    == IntFloatCoercion    = True
+  IntDoubleCoercion   == IntDoubleCoercion   = True
+  LongFloatCoercion   == LongFloatCoercion   = True
+  LongDoubleCoercion  == LongDoubleCoercion  = True
+  FloatDoubleCoercion == FloatDoubleCoercion = True
+  FreeUnion ty1 == FreeUnion ty2 = ty1 == ty2
+  Panic ty1 _ == Panic ty2 _ = ty1 == ty2
 
   _ == _ = False
 
@@ -289,10 +307,17 @@ typeName bt =
     Union ts       -> typeName (V.head ts)
     _              -> renderFullname $ name bt
 
+data FieldStatus =
+    AsIs
+  | Ignored
+  | Defaulted (Ty.Value Schema)
+  deriving (Eq, Show, Generic, NFData)
+
 data Field = Field { fldName    :: Text
                    , fldAliases :: [Text]
                    , fldDoc     :: Maybe Text
                    , fldOrder   :: Maybe Order
+                   , fldStatus  :: FieldStatus
                    , fldType    :: Schema
                    , fldDefault :: Maybe (Ty.Value Schema)
                    }
@@ -377,7 +402,7 @@ parseSchemaJSON context = \case
 
   invalid    -> typeMismatch "Invalid JSON for Avro Schema" invalid
 
--- | Parse aliases, inferring the namespace based on the type being aliases.
+-- | Parse aliases, inferring the namespace based on the type being aliased.
 mkAliases :: TypeName
              -- ^ The name of the type being aliased.
           -> [Text]
@@ -409,7 +434,7 @@ parseField record = \case
 
     let mkAlias name = mkTypeName (Just record) name Nothing
     aliases  <- o .:? "aliases"  .!= []
-    return $ Field name aliases doc order ty def
+    return $ Field name aliases doc order AsIs ty def
   invalid    -> typeMismatch "Field" invalid
 
 instance ToJSON Schema where
@@ -686,6 +711,16 @@ instance FromJSON Order where
 --  * Named types are resolvable
 validateSchema :: Schema -> Parser ()
 validateSchema _sch = return () -- XXX TODO
+
+-- | True iff there are no errors in the schema.
+isSchemaStrict :: Schema -> Bool
+isSchemaStrict Array{item}    = isSchemaStrict item
+isSchemaStrict Map{values}    = isSchemaStrict values
+isSchemaStrict Record{fields} = all (isSchemaStrict . fldType) fields
+isSchemaStrict Union{options} = V.all isSchemaStrict options
+isSchemaStrict FreeUnion{ty}  = isSchemaStrict ty
+isSchemaStrict Panic{}        = False
+isSchemaStrict _              = True
 
 -- | @buildTypeEnvironment schema@ builds a function mapping type names to
 -- the types declared in the traversed schema.

--- a/src/Data/Avro/Schema.hs
+++ b/src/Data/Avro/Schema.hs
@@ -605,6 +605,8 @@ parseAvroJSON union env ty av                  =
             when (len /= size) $
               fail $ "Fixed string wrong size. Expected " <> show size <> " but got " <> show len
             return $ Ty.Fixed ty bytes
+          _ -> fail $ "Expected type String, Enum, Bytes, or Fixed, but found (Type,Value)="
+             <> show (ty, av)
       A.Bool b       -> case ty of
                           Boolean -> return $ Ty.Boolean b
                           _       -> avroTypeMismatch ty "boolean"

--- a/src/Data/Avro/Schema.hs
+++ b/src/Data/Avro/Schema.hs
@@ -452,6 +452,13 @@ schemaToJSON context = \case
   Double         -> A.String "double"
   Bytes          -> A.String "bytes"
   String         -> A.String "string"
+  IntLongCoercion     -> A.String "long"
+  IntFloatCoercion    -> A.String "float"
+  IntDoubleCoercion   -> A.String "double"
+  LongFloatCoercion   -> A.String "float"
+  LongDoubleCoercion  -> A.String "double"
+  FloatDoubleCoercion -> A.String "double"
+  FreeUnion ty        -> schemaToJSON context ty
   Array tn       ->
     object [ "type" .= ("array" :: Text), "items" .= schemaToJSON context tn ]
   Map tn         ->

--- a/src/Data/Avro/Schema/Deconflict.hs
+++ b/src/Data/Avro/Schema/Deconflict.hs
@@ -136,11 +136,11 @@ deconflictFields :: [Field] -> [Field] -> Either String [Field]
 deconflictFields writerFields readerFields =
   sequence $ (deconflictField <$> writerFields) <> defaultedFields
   where
-    defaultedFields = [makeDefaulted f | f <- readerFields, findField f writerFields == Nothing]
+    defaultedFields = [confirmDefaulted f | f <- readerFields, findField f writerFields == Nothing]
 
-    makeDefaulted :: Field -> Either String Field
-    makeDefaulted f
-      | Just def <- fldDefault f = pure f { fldStatus = Defaulted def }
+    confirmDefaulted :: Field -> Either String Field
+    confirmDefaulted f
+      | Just def <- fldDefault f = pure f { fldReadIgnore = True }
       | otherwise = Left $ "No default found for deconflicted field " <> Text.unpack (fldName f)
 
     deconflictField :: Field -> Either String Field
@@ -149,7 +149,7 @@ deconflictFields writerFields readerFields =
         t <- deconflict (fldType writerField) (fldType readerField)
         pure writerField { fldType = t }
       | otherwise =
-        pure writerField { fldStatus = Ignored }
+        pure writerField { fldReadIgnore = True, fldDefault = Nothing }
 
 findField :: Field -> [Field] -> Maybe Field
 findField f fs =

--- a/src/Data/Avro/Schema/Deconflict.hs
+++ b/src/Data/Avro/Schema/Deconflict.hs
@@ -1,0 +1,170 @@
+{-# LANGUAGE TupleSections #-}
+module Data.Avro.Schema.Deconflict
+  ( deconflict
+  ) where
+
+import           Control.Applicative ((<|>))
+import           Data.Avro.Schema    as S
+import           Data.Avro.Types     as T
+import qualified Data.Foldable       as Foldable
+import           Data.HashMap.Strict (HashMap)
+import qualified Data.HashMap.Strict as HashMap
+import           Data.List           (find)
+import           Data.List.NonEmpty  (NonEmpty (..))
+import qualified Data.List.NonEmpty  as NE
+import qualified Data.Map            as M
+import           Data.Semigroup      ((<>))
+import qualified Data.Set            as Set
+import           Data.Text           (Text)
+import qualified Data.Text           as Text
+import qualified Data.Text.Encoding  as Text
+import           Data.Traversable    (forM)
+import           Data.Vector         (Vector)
+import qualified Data.Vector         as V
+
+-- | @deconflict writer reader@ will produce a schema that can encode/decode
+-- with the writer's schema into the form specified by the reader's schema.
+-- The returned schema is lazy in that it may have errors (but those will not
+-- get in the way of pure parsing).
+deconflict :: Schema -- ^ Writer schema
+           -> Schema -- ^ Reader schema
+           -> Schema
+deconflict writerSchema readerSchema = go writerSchema readerSchema
+  where
+    go :: Schema -> Schema -> Schema
+    go aTy bTy
+      | aTy == bTy = aTy
+    go (S.Array aTy) (S.Array bTy) =
+      S.Array $ go aTy bTy
+    go (S.Map aTy) (S.Map bTy) =
+      S.Map $ go aTy bTy
+    go a@S.Enum{} b@S.Enum{}
+      | name a == name b && symbols b `contains` symbols a = S.Enum
+        { name    = name a
+        , aliases = aliases a <> aliases b
+        , doc     = doc a
+        , symbols = symbols a
+        }
+    go a@S.Fixed {} b@S.Fixed {}
+      | name a == name b && size a == size b = S.Fixed
+        { name    = name a
+        , aliases = aliases a <> aliases b
+        , size    = size a
+        }
+    go a@S.Record {} b@S.Record {}
+      | name a == name b && order b `moreSpecified` order a =
+        let fields' = deconflictFields (fields a) (fields b)
+        in S.Record
+          { name    = name a
+          , aliases = aliases a <> aliases b
+          , doc     = doc a
+          , order   = order b
+          , fields  = fields'
+          }
+    go (S.Union xs) (S.Union ys) =
+      let err x = S.Panic x $ "Incorrect payload: union " <> (show . Foldable.toList $ typeName <$> ys) <> " does not contain schema " <> Text.unpack (typeName x)
+      in S.Union $ (\x -> maybe (err x) (go x) (findType x ys)) <$> xs
+    go nonUnion (S.Union ys)
+      | Just y <- findType nonUnion ys =
+        S.FreeUnion (go nonUnion y)
+    go from S.Int | isIntIn from = S.Int
+    go from to | isIntIn   from && isLongOut   to = S.IntLongCoercion
+    go from to | isIntIn   from && isFloatOut  to = S.IntFloatCoercion
+    go from to | isIntIn   from && isDoubleOut to = S.IntDoubleCoercion
+    go from to | isLongIn  from && isLongOut   to = S.Long
+    go from to | isLongIn  from && isFloatOut  to = S.LongFloatCoercion
+    go from to | isLongIn  from && isDoubleOut to = S.LongDoubleCoercion
+    go from to | isFloatIn from && isFloatOut  to = S.Float
+    go from to | isFloatIn from && isDoubleOut to = S.FloatDoubleCoercion
+    go S.Double to | isDoubleOut to = S.Double
+    go S.Bytes  S.String = S.Bytes  -- These are free coercions
+    go S.String S.Bytes  = S.String -- These are free coercions
+    go (S.FreeUnion a) b = go a b -- Free unions are free to discard
+    go a (S.FreeUnion b) = go a b -- Free unions are free to discard
+    go a b = S.Panic a $ "Can not resolve differing writer and reader schemas: " ++ show (a, b)
+
+isIntIn :: Schema -> Bool
+isIntIn S.Int               = True
+isIntIn S.IntLongCoercion   = True
+isIntIn S.IntFloatCoercion  = True
+isIntIn S.IntDoubleCoercion = True
+isIntIn _                   = False
+
+isLongIn :: Schema -> Bool
+isLongIn S.Long               = True
+isLongIn S.LongFloatCoercion  = True
+isLongIn S.LongDoubleCoercion = True
+isLongIn _                    = False
+
+isFloatIn :: Schema -> Bool
+isFloatIn S.Float               = True
+isFloatIn S.FloatDoubleCoercion = True
+isFloatIn _                     = False
+
+isLongOut :: Schema -> Bool
+isLongOut S.Long            = True
+isLongOut S.IntLongCoercion = True
+isLongOut _                 = False
+
+isFloatOut :: Schema -> Bool
+isFloatOut S.Float             = True
+isFloatOut S.IntFloatCoercion  = True
+isFloatOut S.LongFloatCoercion = True
+isFloatOut _                   = False
+
+isDoubleOut :: Schema -> Bool
+isDoubleOut S.Double              = True
+isDoubleOut S.IntDoubleCoercion   = True
+isDoubleOut S.LongDoubleCoercion  = True
+isDoubleOut S.FloatDoubleCoercion = True
+isDoubleOut _                     = False
+
+moreSpecified :: Maybe Order -> Maybe Order -> Bool
+moreSpecified _ Nothing       = True
+moreSpecified _ (Just Ignore) = True
+moreSpecified (Just Ascending)  (Just Ascending)  = True
+moreSpecified (Just Descending) (Just Descending) = True
+moreSpecified _ _ = False
+
+contains :: V.Vector Text -> V.Vector Text -> Bool
+contains container elts =
+  and [e `V.elem` container | e <- V.toList elts]
+
+-- For each field:
+--  1) If it exists in both schemas, deconflict it
+--  2) If it's only in the reader schema and has a default, mark it defaulted.
+--  2) If it's only in the reader schema and has no default, set its type to Panic.
+--  3) If it's only in the writer schema, mark it ignored.
+deconflictFields :: [Field] -> [Field] -> [Field]
+deconflictFields writerFields readerFields =
+  (deconflictField <$> writerFields) <> defaultedFields
+  where
+    defaultedFields = [makeDefaulted f | f <- readerFields, findField f writerFields == Nothing]
+
+    makeDefaulted :: Field -> Field
+    makeDefaulted f
+      | Just def <- fldDefault f = f { fldStatus = Defaulted def }
+      | otherwise = f { fldType =
+        S.Panic (fldType f) ("No default found for deconflicted field "<>Text.unpack (fldName f)) }
+
+    deconflictField :: Field -> Field
+    deconflictField writerField
+      | Just readerField <- findField writerField readerFields =
+        writerField { fldType = deconflict (fldType writerField) (fldType readerField) }
+      | otherwise =
+        writerField { fldStatus = Ignored }
+
+findField :: Field -> [Field] -> Maybe Field
+findField f fs =
+  let
+    byName = find (\x -> fldName x == fldName f) fs
+    allNames fld = Set.fromList (fldName fld : fldAliases fld)
+    fNames = allNames f
+    sameField = not . Set.null . Set.intersection fNames . allNames
+    byAliases = find sameField fs
+  in byName <|> byAliases
+
+findType :: Foldable f => Schema -> f Schema -> Maybe Schema
+findType schema =
+  let tn = typeName schema
+  in Foldable.find ((tn ==) . typeName) -- TODO: Consider aliases

--- a/test/Avro/Codec/BoolSpec.hs
+++ b/test/Avro/Codec/BoolSpec.hs
@@ -25,7 +25,7 @@ newtype OnlyBool = OnlyBool
 
 onlyBoolSchema :: Schema
 onlyBoolSchema =
-  let fld nm = Field nm [] Nothing Nothing AsIs
+  let fld nm = Field nm [] Nothing Nothing False
    in Record "test.contract.OnlyBool" [] Nothing Nothing
         [ fld "onlyBoolValue" Boolean Nothing
         ]

--- a/test/Avro/Codec/BoolSpec.hs
+++ b/test/Avro/Codec/BoolSpec.hs
@@ -25,7 +25,7 @@ newtype OnlyBool = OnlyBool
 
 onlyBoolSchema :: Schema
 onlyBoolSchema =
-  let fld nm = Field nm [] Nothing Nothing
+  let fld nm = Field nm [] Nothing Nothing AsIs
    in Record "test.contract.OnlyBool" [] Nothing Nothing
         [ fld "onlyBoolValue" Boolean Nothing
         ]

--- a/test/Avro/Codec/DoubleSpec.hs
+++ b/test/Avro/Codec/DoubleSpec.hs
@@ -19,7 +19,7 @@ newtype OnlyDouble = OnlyDouble
 
 onlyDoubleSchema :: Schema
 onlyDoubleSchema =
-  let fld nm = Field nm [] Nothing Nothing
+  let fld nm = Field nm [] Nothing Nothing AsIs
   in Record "test.contract.OnlyDouble" [] Nothing Nothing
         [ fld "onlyDoubleValue" Double Nothing
         ]

--- a/test/Avro/Codec/DoubleSpec.hs
+++ b/test/Avro/Codec/DoubleSpec.hs
@@ -19,7 +19,7 @@ newtype OnlyDouble = OnlyDouble
 
 onlyDoubleSchema :: Schema
 onlyDoubleSchema =
-  let fld nm = Field nm [] Nothing Nothing AsIs
+  let fld nm = Field nm [] Nothing Nothing False
   in Record "test.contract.OnlyDouble" [] Nothing Nothing
         [ fld "onlyDoubleValue" Double Nothing
         ]

--- a/test/Avro/Codec/FloatSpec.hs
+++ b/test/Avro/Codec/FloatSpec.hs
@@ -19,7 +19,7 @@ newtype OnlyFloat = OnlyFloat
 
 onlyFloatSchema :: Schema
 onlyFloatSchema =
-  let fld nm = Field nm [] Nothing Nothing
+  let fld nm = Field nm [] Nothing Nothing AsIs
   in Record "test.contract.OnlyFloat" [] Nothing Nothing
         [ fld "onlyFloatValue" Float Nothing
         ]

--- a/test/Avro/Codec/FloatSpec.hs
+++ b/test/Avro/Codec/FloatSpec.hs
@@ -19,7 +19,7 @@ newtype OnlyFloat = OnlyFloat
 
 onlyFloatSchema :: Schema
 onlyFloatSchema =
-  let fld nm = Field nm [] Nothing Nothing AsIs
+  let fld nm = Field nm [] Nothing Nothing False
   in Record "test.contract.OnlyFloat" [] Nothing Nothing
         [ fld "onlyFloatValue" Float Nothing
         ]

--- a/test/Avro/Codec/Int64Spec.hs
+++ b/test/Avro/Codec/Int64Spec.hs
@@ -32,7 +32,7 @@ newtype OnlyInt64 = OnlyInt64
 
 onlyInt64Schema :: Schema
 onlyInt64Schema =
-  let fld nm = Field nm [] Nothing Nothing
+  let fld nm = Field nm [] Nothing Nothing AsIs
    in Record "test.contract.OnlyInt64" [] Nothing Nothing
         [ fld "onlyInt64Value"    Long Nothing
         ]

--- a/test/Avro/Codec/Int64Spec.hs
+++ b/test/Avro/Codec/Int64Spec.hs
@@ -32,7 +32,7 @@ newtype OnlyInt64 = OnlyInt64
 
 onlyInt64Schema :: Schema
 onlyInt64Schema =
-  let fld nm = Field nm [] Nothing Nothing AsIs
+  let fld nm = Field nm [] Nothing Nothing False
    in Record "test.contract.OnlyInt64" [] Nothing Nothing
         [ fld "onlyInt64Value"    Long Nothing
         ]

--- a/test/Avro/Codec/MaybeSpec.hs
+++ b/test/Avro/Codec/MaybeSpec.hs
@@ -22,7 +22,7 @@ newtype OnlyMaybeBool = OnlyMaybeBool
 
 onlyMaybeBoolSchema :: Schema
 onlyMaybeBoolSchema =
-  let fld nm = Field nm [] Nothing Nothing
+  let fld nm = Field nm [] Nothing Nothing AsIs
    in Record "test.contract.onlyMaybeBool" [] Nothing Nothing
         [ fld "onlyMaybeBoolValue" (mkUnion (Null :| [Boolean])) Nothing
         ]

--- a/test/Avro/Codec/MaybeSpec.hs
+++ b/test/Avro/Codec/MaybeSpec.hs
@@ -22,7 +22,7 @@ newtype OnlyMaybeBool = OnlyMaybeBool
 
 onlyMaybeBoolSchema :: Schema
 onlyMaybeBoolSchema =
-  let fld nm = Field nm [] Nothing Nothing AsIs
+  let fld nm = Field nm [] Nothing Nothing False
    in Record "test.contract.onlyMaybeBool" [] Nothing Nothing
         [ fld "onlyMaybeBoolValue" (mkUnion (Null :| [Boolean])) Nothing
         ]

--- a/test/Avro/Codec/NestedSpec.hs
+++ b/test/Avro/Codec/NestedSpec.hs
@@ -23,7 +23,7 @@ data ParentType = ParentType
 
 childTypeSchema :: Schema
 childTypeSchema =
-  let fld nm = Field nm [] Nothing Nothing AsIs
+  let fld nm = Field nm [] Nothing Nothing False
   in Record "test.contract.ChildType" [] Nothing Nothing
         [ fld "childValue1" Long Nothing
         , fld "childValue2" Long Nothing
@@ -31,7 +31,7 @@ childTypeSchema =
 
 parentTypeSchema :: Schema
 parentTypeSchema =
-  let fld nm = Field nm [] Nothing Nothing AsIs
+  let fld nm = Field nm [] Nothing Nothing False
   in Record "test.contract.ParentType" [] Nothing Nothing
         [ fld "parentValue1" Long             Nothing
         , fld "parentValue2" (Array childTypeSchema)  Nothing]

--- a/test/Avro/Codec/NestedSpec.hs
+++ b/test/Avro/Codec/NestedSpec.hs
@@ -23,7 +23,7 @@ data ParentType = ParentType
 
 childTypeSchema :: Schema
 childTypeSchema =
-  let fld nm = Field nm [] Nothing Nothing
+  let fld nm = Field nm [] Nothing Nothing AsIs
   in Record "test.contract.ChildType" [] Nothing Nothing
         [ fld "childValue1" Long Nothing
         , fld "childValue2" Long Nothing
@@ -31,7 +31,7 @@ childTypeSchema =
 
 parentTypeSchema :: Schema
 parentTypeSchema =
-  let fld nm = Field nm [] Nothing Nothing
+  let fld nm = Field nm [] Nothing Nothing AsIs
   in Record "test.contract.ParentType" [] Nothing Nothing
         [ fld "parentValue1" Long             Nothing
         , fld "parentValue2" (Array childTypeSchema)  Nothing]

--- a/test/Avro/Codec/TextSpec.hs
+++ b/test/Avro/Codec/TextSpec.hs
@@ -20,7 +20,7 @@ newtype OnlyText = OnlyText
 
 onlyTextSchema :: Schema
 onlyTextSchema =
-  let fld nm = Field nm [] Nothing Nothing AsIs
+  let fld nm = Field nm [] Nothing Nothing False
   in Record "test.contract.OnlyText" [] Nothing Nothing
         [ fld "onlyTextValue" String Nothing
         ]

--- a/test/Avro/Codec/TextSpec.hs
+++ b/test/Avro/Codec/TextSpec.hs
@@ -20,7 +20,7 @@ newtype OnlyText = OnlyText
 
 onlyTextSchema :: Schema
 onlyTextSchema =
-  let fld nm = Field nm [] Nothing Nothing
+  let fld nm = Field nm [] Nothing Nothing AsIs
   in Record "test.contract.OnlyText" [] Nothing Nothing
         [ fld "onlyTextValue" String Nothing
         ]

--- a/test/Avro/Deconflict/B/README.md
+++ b/test/Avro/Deconflict/B/README.md
@@ -1,1 +1,1 @@
-# Adding an nested optional field
+# Adding a nested optional field

--- a/test/Avro/Deconflict/C/README.md
+++ b/test/Avro/Deconflict/C/README.md
@@ -1,1 +1,1 @@
-# Removing an nested optional field
+# Removing a nested optional field

--- a/test/Avro/Deconflict/D/README.md
+++ b/test/Avro/Deconflict/D/README.md
@@ -1,0 +1,1 @@
+# Adding a recursive optional field

--- a/test/Avro/Deconflict/D/Reader.hs
+++ b/test/Avro/Deconflict/D/Reader.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes       #-}
+{-# LANGUAGE TemplateHaskell   #-}
+
+module Avro.Deconflict.D.Reader where
+
+import Data.Avro.Deriving
+import Text.RawString.QQ
+
+deriveAvroFromByteString [r|
+[
+{ "name": "Foo",
+  "type": "record",
+  "fields": [
+    { "name": "constructor",
+      "type": [
+        { "name": "Bar",
+          "type": "record",
+          "fields": [
+            { "name": "fieldA", "type": "int" },
+            { "name": "fieldB", "type": [ "null", "string" ], "default": null }
+          ]
+        },
+        { "name": "Baz",
+          "type": "record",
+          "fields": [
+            { "name": "fieldC", "type": "Foo" }
+          ]
+        }
+      ]
+    }
+  ]
+}
+]
+|]
+
+sampleValue :: Foo
+sampleValue =
+  Foo (Right (Baz (Foo (Right (Baz (Foo (Left $ Bar 12 Nothing)))))))

--- a/test/Avro/Deconflict/D/Writer.hs
+++ b/test/Avro/Deconflict/D/Writer.hs
@@ -1,0 +1,39 @@
+{-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes       #-}
+{-# LANGUAGE TemplateHaskell   #-}
+
+module Avro.Deconflict.D.Writer where
+
+import Data.Avro.Deriving
+import Text.RawString.QQ
+
+deriveAvroFromByteString [r|
+[
+{ "name": "Foo",
+  "type": "record",
+  "fields": [
+    { "name": "constructor",
+      "type": [
+        { "name": "Bar",
+          "type": "record",
+          "fields": [
+            { "name": "fieldA", "type": "int" }
+          ]
+        },
+        { "name": "Baz",
+          "type": "record",
+          "fields": [
+            { "name": "fieldC", "type": "Foo" }
+          ]
+        }
+      ]
+    }
+  ]
+}
+]
+|]
+
+sampleValue :: Foo
+sampleValue =
+  Foo (Right (Baz (Foo (Right (Baz (Foo (Left $ Bar 12)))))))

--- a/test/Avro/DeconflictSpec.hs
+++ b/test/Avro/DeconflictSpec.hs
@@ -20,9 +20,9 @@ import qualified Avro.Deconflict.D.Reader         as DR
 import qualified Avro.Deconflict.D.Writer         as DW
 import qualified Data.Avro.Decode                 as A (decodeAvro)
 import qualified Data.Avro.Decode.Lazy            as AL
-import qualified Data.Avro.Decode.Lazy.Deconflict as AL
-import qualified Data.Avro.Deconflict             as A
 import qualified Data.Avro.Types                  as Ty
+
+import qualified Data.Avro.Schema.Deconflict as Dec
 
 import Test.Hspec
 
@@ -33,14 +33,14 @@ spec = describe "Avro.DeconflictSpec" $ do
   describe "Type A" $ do
     it "should deconflict simple message" $ do
       let payload = A.encode $ AW.Inner 3
-      let Right decodedAvro = A.decodeAvro AW.schema'Inner payload
-      let Right deconflicted = deconflict AW.schema'Inner AR.schema'Inner decodedAvro
+      let deconflictedSchema = Dec.deconflict AW.schema'Inner AR.schema'Inner
+      let Right deconflicted = A.decodeAvro deconflictedSchema payload
       fromAvro deconflicted `shouldBe` Success (AR.Inner 3 Nothing)
 
-    it "should deconflict nested message" $ do
+    it "should deconflict strict message" $ do
       let payload = A.encode AW.sampleValue
-      let Right decodedAvro = A.decodeAvro AW.schema'Outer payload
-      let Right deconflicted = deconflict AW.schema'Outer AR.schema'Outer decodedAvro
+      let deconflictedSchema = Dec.deconflict AW.schema'Outer AR.schema'Outer
+      let Right deconflicted = A.decodeAvro deconflictedSchema payload
 
       fromAvro deconflicted `shouldBe` Success AR.sampleValue
 
@@ -54,35 +54,21 @@ spec = describe "Avro.DeconflictSpec" $ do
 
     it "should deconflict lazy value" $ do
       let payload = A.encode AW.sampleValue
-      let decodedAvro = AL.decodeAvro AW.schema'Outer payload
-      let deconflicted = AL.deconflict AW.schema'Outer AR.schema'Outer decodedAvro
+      let deconflictedSchema = Dec.deconflict AW.schema'Outer AR.schema'Outer
+      let deconflicted = AL.decodeAvro deconflictedSchema payload
 
       AL.fromLazyAvro deconflicted `shouldBe` Success AR.sampleValue
 
-    it "should deconflict strict value" $ do
-      let payload = A.encode AW.sampleValue
-      let Right decodedAvro = A.decodeAvro AW.schema'Outer payload
-      let Right deconflicted = A.deconflict AW.schema'Outer AR.schema'Outer decodedAvro
-
-      A.fromAvro deconflicted `shouldBe` Success AR.sampleValue
-
 
   describe "Type B" $ do
-    it "should deconflict complex type" $ do
-      let payload = A.encode BW.sampleValue
-      let decodedAvro = AL.decodeAvro BW.schema'Foo payload
-      let res = AL.deconflict BW.schema'Foo BR.schema'Foo decodedAvro
-
-      AL.fromLazyAvro res `shouldBe` Success BR.sampleValue
-
     it "should deconflict lazy container" $ do
       w <- liftIO $ A.encodeContainer [[ BW.sampleValue ]]
       AL.decodeContainer w `shouldBe` [ Right BR.sampleValue ]
 
     it "should deconflict lazy value" $ do
       let payload = A.encode BW.sampleValue
-      let decodedAvro = AL.decodeAvro BW.schema'Foo payload
-      let deconflicted = AL.deconflict BW.schema'Foo BR.schema'Foo decodedAvro
+      let deconflictedSchema = Dec.deconflict BW.schema'Foo BR.schema'Foo
+      let deconflicted = AL.decodeAvro deconflictedSchema payload
 
       AL.fromLazyAvro deconflicted `shouldBe` Success BR.sampleValue
 
@@ -92,27 +78,20 @@ spec = describe "Avro.DeconflictSpec" $ do
 
     it "should deconflict strict value" $ do
       let payload = A.encode BW.sampleValue
-      let Right decodedAvro = A.decodeAvro BW.schema'Foo payload
-      let Right deconflicted = A.deconflict BW.schema'Foo BR.schema'Foo decodedAvro
+      let deconflictedSchema = Dec.deconflict BW.schema'Foo BR.schema'Foo
+      let Right deconflicted = A.decodeAvro deconflictedSchema payload
 
       A.fromAvro deconflicted `shouldBe` Success BR.sampleValue
 
   describe "Type C" $ do
-    it "should deconflict complex type" $ do
-      let payload = A.encode CW.sampleValue
-      let decodedAvro = AL.decodeAvro CW.schema'Foo payload
-      let res = AL.deconflict CW.schema'Foo CR.schema'Foo decodedAvro
-
-      AL.fromLazyAvro res `shouldBe` Success CR.sampleValue
-
     it "should deconflict lazy container" $ do
       w <- liftIO $ A.encodeContainer [[ CW.sampleValue ]]
       AL.decodeContainer w `shouldBe` [ Right CR.sampleValue ]
 
     it "should deconflict lazy value" $ do
       let payload = A.encode CW.sampleValue
-      let decodedAvro = AL.decodeAvro CW.schema'Foo payload
-      let deconflicted = AL.deconflict CW.schema'Foo CR.schema'Foo decodedAvro
+      let deconflictedSchema = Dec.deconflict CW.schema'Foo CR.schema'Foo
+      let deconflicted = AL.decodeAvro deconflictedSchema payload
 
       AL.fromLazyAvro deconflicted `shouldBe` Success CR.sampleValue
 
@@ -122,27 +101,20 @@ spec = describe "Avro.DeconflictSpec" $ do
 
     it "should deconflict strict value" $ do
       let payload = A.encode CW.sampleValue
-      let Right decodedAvro = A.decodeAvro CW.schema'Foo payload
-      let Right deconflicted = A.deconflict CW.schema'Foo CR.schema'Foo decodedAvro
+      let deconflictedSchema = Dec.deconflict CW.schema'Foo CR.schema'Foo
+      let Right deconflicted = A.decodeAvro deconflictedSchema payload
 
       A.fromAvro deconflicted `shouldBe` Success CR.sampleValue
 
   describe "Type D" $ do
-    it "should deconflict complex type" $ do
-      let payload = A.encode DW.sampleValue
-      let decodedAvro = AL.decodeAvro DW.schema'Foo payload
-      let res = AL.deconflict DW.schema'Foo DR.schema'Foo decodedAvro
-
-      AL.fromLazyAvro res `shouldBe` Success DR.sampleValue
-
     it "should deconflict lazy container" $ do
       w <- liftIO $ A.encodeContainer [[ DW.sampleValue ]]
       AL.decodeContainer w `shouldBe` [ Right DR.sampleValue ]
 
     it "should deconflict lazy value" $ do
       let payload = A.encode DW.sampleValue
-      let decodedAvro = AL.decodeAvro DW.schema'Foo payload
-      let deconflicted = AL.deconflict DW.schema'Foo DR.schema'Foo decodedAvro
+      let deconflictedSchema = Dec.deconflict DW.schema'Foo DR.schema'Foo
+      let deconflicted = AL.decodeAvro deconflictedSchema payload
 
       AL.fromLazyAvro deconflicted `shouldBe` Success DR.sampleValue
 
@@ -152,7 +124,7 @@ spec = describe "Avro.DeconflictSpec" $ do
 
     it "should deconflict strict value" $ do
       let payload = A.encode DW.sampleValue
-      let Right decodedAvro = A.decodeAvro DW.schema'Foo payload
-      let Right deconflicted = A.deconflict DW.schema'Foo DR.schema'Foo decodedAvro
+      let deconflictedSchema = Dec.deconflict DW.schema'Foo DR.schema'Foo
+      let Right deconflicted = A.decodeAvro deconflictedSchema payload
 
       A.fromAvro deconflicted `shouldBe` Success DR.sampleValue

--- a/test/Avro/DeconflictSpec.hs
+++ b/test/Avro/DeconflictSpec.hs
@@ -33,13 +33,13 @@ spec = describe "Avro.DeconflictSpec" $ do
   describe "Type A" $ do
     it "should deconflict simple message" $ do
       let payload = A.encode $ AW.Inner 3
-      let deconflictedSchema = Dec.deconflict AW.schema'Inner AR.schema'Inner
+      let Right deconflictedSchema = Dec.deconflict AW.schema'Inner AR.schema'Inner
       let Right deconflicted = A.decodeAvro deconflictedSchema payload
       fromAvro deconflicted `shouldBe` Success (AR.Inner 3 Nothing)
 
     it "should deconflict strict message" $ do
       let payload = A.encode AW.sampleValue
-      let deconflictedSchema = Dec.deconflict AW.schema'Outer AR.schema'Outer
+      let Right deconflictedSchema = Dec.deconflict AW.schema'Outer AR.schema'Outer
       let Right deconflicted = A.decodeAvro deconflictedSchema payload
 
       fromAvro deconflicted `shouldBe` Success AR.sampleValue
@@ -54,7 +54,7 @@ spec = describe "Avro.DeconflictSpec" $ do
 
     it "should deconflict lazy value" $ do
       let payload = A.encode AW.sampleValue
-      let deconflictedSchema = Dec.deconflict AW.schema'Outer AR.schema'Outer
+      let Right deconflictedSchema = Dec.deconflict AW.schema'Outer AR.schema'Outer
       let deconflicted = AL.decodeAvro deconflictedSchema payload
 
       AL.fromLazyAvro deconflicted `shouldBe` Success AR.sampleValue
@@ -67,7 +67,7 @@ spec = describe "Avro.DeconflictSpec" $ do
 
     it "should deconflict lazy value" $ do
       let payload = A.encode BW.sampleValue
-      let deconflictedSchema = Dec.deconflict BW.schema'Foo BR.schema'Foo
+      let Right deconflictedSchema = Dec.deconflict BW.schema'Foo BR.schema'Foo
       let deconflicted = AL.decodeAvro deconflictedSchema payload
 
       AL.fromLazyAvro deconflicted `shouldBe` Success BR.sampleValue
@@ -78,7 +78,7 @@ spec = describe "Avro.DeconflictSpec" $ do
 
     it "should deconflict strict value" $ do
       let payload = A.encode BW.sampleValue
-      let deconflictedSchema = Dec.deconflict BW.schema'Foo BR.schema'Foo
+      let Right deconflictedSchema = Dec.deconflict BW.schema'Foo BR.schema'Foo
       let Right deconflicted = A.decodeAvro deconflictedSchema payload
 
       A.fromAvro deconflicted `shouldBe` Success BR.sampleValue
@@ -90,7 +90,7 @@ spec = describe "Avro.DeconflictSpec" $ do
 
     it "should deconflict lazy value" $ do
       let payload = A.encode CW.sampleValue
-      let deconflictedSchema = Dec.deconflict CW.schema'Foo CR.schema'Foo
+      let Right deconflictedSchema = Dec.deconflict CW.schema'Foo CR.schema'Foo
       let deconflicted = AL.decodeAvro deconflictedSchema payload
 
       AL.fromLazyAvro deconflicted `shouldBe` Success CR.sampleValue
@@ -101,7 +101,7 @@ spec = describe "Avro.DeconflictSpec" $ do
 
     it "should deconflict strict value" $ do
       let payload = A.encode CW.sampleValue
-      let deconflictedSchema = Dec.deconflict CW.schema'Foo CR.schema'Foo
+      let Right deconflictedSchema = Dec.deconflict CW.schema'Foo CR.schema'Foo
       let Right deconflicted = A.decodeAvro deconflictedSchema payload
 
       A.fromAvro deconflicted `shouldBe` Success CR.sampleValue
@@ -113,7 +113,7 @@ spec = describe "Avro.DeconflictSpec" $ do
 
     it "should deconflict lazy value" $ do
       let payload = A.encode DW.sampleValue
-      let deconflictedSchema = Dec.deconflict DW.schema'Foo DR.schema'Foo
+      let Right deconflictedSchema = Dec.deconflict DW.schema'Foo DR.schema'Foo
       let deconflicted = AL.decodeAvro deconflictedSchema payload
 
       AL.fromLazyAvro deconflicted `shouldBe` Success DR.sampleValue
@@ -124,7 +124,7 @@ spec = describe "Avro.DeconflictSpec" $ do
 
     it "should deconflict strict value" $ do
       let payload = A.encode DW.sampleValue
-      let deconflictedSchema = Dec.deconflict DW.schema'Foo DR.schema'Foo
+      let Right deconflictedSchema = Dec.deconflict DW.schema'Foo DR.schema'Foo
       let Right deconflicted = A.decodeAvro deconflictedSchema payload
 
       A.fromAvro deconflicted `shouldBe` Success DR.sampleValue

--- a/test/Avro/NamespaceSpec.hs
+++ b/test/Avro/NamespaceSpec.hs
@@ -42,7 +42,7 @@ expected = Record
   , order   = Just Ascending
   , fields  = [field "bar" bar, field "baz" $ NamedType "com.example.baz.Baz"]
   }
-  where field name schema = Field name [] Nothing (Just Ascending) AsIs schema Nothing
+  where field name schema = Field name [] Nothing (Just Ascending) False schema Nothing
 
         bar = Record
           { name    = "com.example.Bar"
@@ -73,7 +73,7 @@ expectedNullNamespace = Record
   , order   = Just Ascending
   , fields  = [field "bar" $ NamedType "Bar", field "baz" $ NamedType "com.example.Baz"]
   }
-  where field name schema = Field name [] Nothing (Just Ascending) AsIs schema Nothing
+  where field name schema = Field name [] Nothing (Just Ascending) False schema Nothing
 
 
 getFileName :: FilePath -> IO FilePath

--- a/test/Avro/NamespaceSpec.hs
+++ b/test/Avro/NamespaceSpec.hs
@@ -42,7 +42,7 @@ expected = Record
   , order   = Just Ascending
   , fields  = [field "bar" bar, field "baz" $ NamedType "com.example.baz.Baz"]
   }
-  where field name schema = Field name [] Nothing (Just Ascending) schema Nothing
+  where field name schema = Field name [] Nothing (Just Ascending) AsIs schema Nothing
 
         bar = Record
           { name    = "com.example.Bar"
@@ -73,7 +73,7 @@ expectedNullNamespace = Record
   , order   = Just Ascending
   , fields  = [field "bar" $ NamedType "Bar", field "baz" $ NamedType "com.example.Baz"]
   }
-  where field name schema = Field name [] Nothing (Just Ascending) schema Nothing
+  where field name schema = Field name [] Nothing (Just Ascending) AsIs schema Nothing
 
 
 getFileName :: FilePath -> IO FilePath

--- a/test/Avro/THUnionSpec.hs
+++ b/test/Avro/THUnionSpec.hs
@@ -50,7 +50,7 @@ spec = describe "Avro.THUnionSpec: Schema with unions." $ do
         , unionsFive        = E5_5 $ NotFoo { notFooStuff = "not foo stuff" }
         }
 
-      field name schema def = Schema.Field name [] Nothing (Just Schema.Ascending) schema def
+      field name schema def = Schema.Field name [] Nothing (Just Schema.Ascending) Schema.AsIs schema def
       record name fields =
         Schema.Record name [] Nothing (Just Schema.Ascending) fields
       named = Schema.NamedType

--- a/test/Avro/THUnionSpec.hs
+++ b/test/Avro/THUnionSpec.hs
@@ -50,7 +50,7 @@ spec = describe "Avro.THUnionSpec: Schema with unions." $ do
         , unionsFive        = E5_5 $ NotFoo { notFooStuff = "not foo stuff" }
         }
 
-      field name schema def = Schema.Field name [] Nothing (Just Schema.Ascending) Schema.AsIs schema def
+      field name schema def = Schema.Field name [] Nothing (Just Schema.Ascending) False schema def
       record name fields =
         Schema.Record name [] Nothing (Just Schema.Ascending) fields
       named = Schema.NamedType

--- a/test/Avro/ToAvroSpec.hs
+++ b/test/Avro/ToAvroSpec.hs
@@ -31,7 +31,7 @@ data TypesTestMessage = TypesTestMessage
 
 tmSchema :: Schema
 tmSchema =
-  let fld nm = Field nm [] Nothing Nothing
+  let fld nm = Field nm [] Nothing Nothing AsIs
    in Record "avro.haskell.test.TypesTestMessage" [] Nothing Nothing
         [ fld "id" Long Nothing
         , fld "name" String Nothing

--- a/test/Avro/ToAvroSpec.hs
+++ b/test/Avro/ToAvroSpec.hs
@@ -31,7 +31,7 @@ data TypesTestMessage = TypesTestMessage
 
 tmSchema :: Schema
 tmSchema =
-  let fld nm = Field nm [] Nothing Nothing AsIs
+  let fld nm = Field nm [] Nothing Nothing False
    in Record "avro.haskell.test.TypesTestMessage" [] Nothing Nothing
         [ fld "id" Long Nothing
         , fld "name" String Nothing

--- a/test/Example1.hs
+++ b/test/Example1.hs
@@ -26,7 +26,7 @@ msSchema =
       , fld "intvalue" Long Nothing
       ]
      where
-     fld nm ty def = Field nm [] Nothing Nothing ty def
+     fld nm ty def = Field nm [] Nothing Nothing AsIs ty def
      eOrS = mkUnion (meSchema :| [String])
 
 -- Encoding data, via the ToAvro class, requires both the routine that encodes

--- a/test/Example1.hs
+++ b/test/Example1.hs
@@ -26,7 +26,7 @@ msSchema =
       , fld "intvalue" Long Nothing
       ]
      where
-     fld nm ty def = Field nm [] Nothing Nothing AsIs ty def
+     fld nm ty def = Field nm [] Nothing Nothing False ty def
      eOrS = mkUnion (meSchema :| [String])
 
 -- Encoding data, via the ToAvro class, requires both the routine that encodes


### PR DESCRIPTION
## Description
As discussed in the comments of PR https://github.com/haskell-works/avro/pull/117 (see https://github.com/haskell-works/avro/pull/117#issuecomment-549036337 in particular), schema deconflicting would be a little more sensible if it functioned directly on the schemas and not on avro values.  That is, it would make more sense for schema deconflicting to have a type like
```haskell
deconflict :: Schema -> Schema -> Either String Schema
```
than
```haskell
deconflict :: Schema -> Schema -> T.Value Type -> Either String (T.Value Type)
```
Indeed, acting directly on the schemas allows us to go one step further: it becomes simple to make the deconflicting process lazy, only forcing strictness if the user wants to call `fromAvro` strictly.  Thus, we can actually make deconflicting have  the type:
```haskell
deconflict :: Schema -> Schema -> Schema
```
This PR introduces such a `deconflict` function.

## Changes
Internally, I needed to slightly extend the type of `Schema` and `Field` to make this possible.  This had knock-on effects on both the strict and lazy versions of `getAvroOf`.  Specifically, for `Schema`, I added  the following constructors:
```haskell
data Type = ...
  | IntLongCoercion
  | IntFloatCoercion
  | IntDoubleCoercion
  | LongFloatCoercion
  | LongDoubleCoercion
  | FloatDoubleCoercion
  | FreeUnion { ty :: Type }
  | Panic { ty :: Type, err :: String }
```
The first 6 are for numeric type coercions and are pretty straightforward.  We need to know the original type so that we parse correctly, and then we need to know the reader type so that we do  the right conversion.

The `FreeUnion` constructor is to allow the situation where the writer does not expect a union type but the reader does.  In this case, we parse assuming no union and then inject the value into a "free" singleton union.  (Note that the reverse situation weirdly used to be allowed in deconflicting, but I didn't support it in this version.   It doesn't make a lot of sense to me, although it could be supported with something like `FakeUnion { ty :: Type, options :: Vector Type }`.)

The `Panic` constructor is what allows the Schema to be lazy.  It contains the type that the reader expects to parse (so lazy parsing can continue) but its presence indicates that deconflicting failed.  For lazy parsing, an `Error` value is produced with  the given error message, and for strict parsing, the error message is immediately thrown.

The `Field` type has one new field: `fldStatus  :: FieldStatus` where
```haskell
data FieldStatus =
    AsIs
  | Ignored
  | Defaulted (Ty.Value Type)
```
By default, all fields  have  status `AsIs`, indicating that they are normal fields.  If a field is not present in the writer but is in the reader (with a default value), then the status is set to `Defaulted` with the default (and if no default is present, the field's type is set to `Panic`).  On the other hand, if the field is in the reader but not the writer, then its status is set to `Ignored`.  We keep it present in the schema so that it can be properly parsed, but the parsing functions then ignore the values they found.

### Deprecation
I'm not sure what you guys want to do with the old deconflicting code, but to prevent breakages, I've currently left the modules there with deprecation pragmas.

## Performance
The benchmark suite is not set up to handle benchmarking deconflicting in this way; it produces many avro objects that are then converted to different avro objects via the old deconflicting process.  The new method skips this step entirely by doing a single pass through the schema and then parsing directly into the final avro object.  I'm not sure the best way to compare these methods.

## Looking Further
Having the avro object as an intermediate type used to be necessary for schema deconflicting, and the ability to deconflict (i.e., be backwards compatible) is a really great feature of avro.  With this new deconflicting style, the intermediate avro representation is no longer strictly necessary.  In other words, one could write a custom version of `getAvroOf` and hook it up to `decodeContainerWith` and parse straight to some target value they want.  Basically, that probably means we can write a version of `fromAvro` that goes straight from bytestring to Haskell types, which would be pretty cool!