### PR TITLE
Use Schema instead of Type

### DIFF
--- a/src/Data/Avro.hs
+++ b/src/Data/Avro.hs
@@ -102,7 +102,7 @@ type Avro a = (FromAvro a, ToAvro a)
 -- | Decode a lazy bytestring using a 'Schema' of the return type.
 decode :: forall a. FromAvro a => ByteString -> Result a
 decode bytes =
-  case D.decodeAvro (untag (schema :: Tagged a Type)) bytes of
+  case D.decodeAvro (untag (schema :: Tagged a Schema)) bytes of
       Right val -> fromAvro val
       Left err  -> Error err
 
@@ -189,14 +189,14 @@ decodeContainerBytes bs =
                                  G.bytesRead
        G.getLazyByteString (end-start)
 
-record :: Foldable f => Type -> f (Text,T.Value Type) -> T.Value Type
+record :: Foldable f => Schema -> f (Text,T.Value Schema) -> T.Value Schema
 record ty = T.Record ty . HashMap.fromList . toList
 
-fixed :: Type -> B.ByteString -> T.Value Type
+fixed :: Schema -> B.ByteString -> T.Value Schema
 fixed = T.Fixed
 -- @enumToAvro val@ will generate an Avro encoded value of enum suitable
 -- for serialization ('encode').
--- enumToAvro :: (Show a, Enum a, Bounded a, Generic a) => a -> T.Value Type
+-- enumToAvro :: (Show a, Enum a, Bounded a, Generic a) => a -> T.Value Schema
 -- enumToAvro e = T.Enum ty (show e)
 --  where
 --   ty = S.Enum nm Nothing [] Nothing (map (Text.pack . show) [minBound..maxBound])

--- a/src/Data/Avro/Decode.hs
+++ b/src/Data/Avro/Decode.hs
@@ -51,7 +51,7 @@ import           Data.Avro.Zag
 import           Data.Avro.Decode.Strict.Internal
 
 -- | Decode bytes into a 'Value' as described by Schema.
-decodeAvro :: Schema -> BL.ByteString -> Either String (T.Value Type)
+decodeAvro :: Schema -> BL.ByteString -> Either String (T.Value Schema)
 decodeAvro sch = either (\(_,_,s) -> Left s) (\(_,_,a) -> Right a) . runGetOrFail (getAvroOf sch)
 {-# INLINABLE decodeAvro #-}
 
@@ -61,7 +61,7 @@ decodeAvro sch = either (\(_,_,s) -> Left s) (\(_,_,a) -> Right a) . runGetOrFai
 --
 -- "Data.Avro.Decode.Lazy" provides functions to decode Avro containers
 -- in a lazy, streaming fashion.
-decodeContainer :: BL.ByteString -> Either String (Schema, [[T.Value Type]])
+decodeContainer :: BL.ByteString -> Either String (Schema, [[T.Value Schema]])
 decodeContainer = decodeContainerWith getAvroOf
 {-# INLINABLE decodeContainer #-}
 

--- a/src/Data/Avro/Decode/Lazy/FromLazyAvro.hs
+++ b/src/Data/Avro/Decode/Lazy/FromLazyAvro.hs
@@ -35,10 +35,10 @@ import           Data.Word
 -- without converting to strict `Value` and then 'FromAvro'
 -- can be very beneficial from the performance point of view.
 class HasAvroSchema a => FromLazyAvro a where
-  fromLazyAvro :: LazyValue Type -> Result a
+  fromLazyAvro :: LazyValue Schema -> Result a
 
 --  | Same as '(.:)' but works on `LazyValue`.
-(.~:) :: FromLazyAvro a => HashMap.HashMap Text (LazyValue Type) -> Text -> Result a
+(.~:) :: FromLazyAvro a => HashMap.HashMap Text (LazyValue Schema) -> Text -> Result a
 (.~:) obj key =
   case HashMap.lookup key obj of
     Nothing -> fail $ "Requested field not available: " <> show key
@@ -49,8 +49,8 @@ instance (FromLazyAvro a, FromLazyAvro b) => FromLazyAvro (Either a b) where
     | S.matches branch schemaA = Left  <$> fromLazyAvro x
     | S.matches branch schemaB = Right <$> fromLazyAvro x
     | otherwise              = badValue e "Either"
-    where Tagged schemaA = schema :: Tagged a Type
-          Tagged schemaB = schema :: Tagged b Type
+    where Tagged schemaA = schema :: Tagged a Schema
+          Tagged schemaB = schema :: Tagged b Schema
   fromLazyAvro x = badValue x "Either"
 
 instance FromLazyAvro Bool where

--- a/src/Data/Avro/Decode/Strict/Internal.hs
+++ b/src/Data/Avro/Decode/Strict/Internal.hs
@@ -39,13 +39,13 @@ import qualified Data.Avro.Types      as T
 import           Data.Avro.Zag
 
 {-# INLINABLE getAvroOf #-}
-getAvroOf :: Schema -> Get (T.Value Type)
+getAvroOf :: Schema -> Get (T.Value Schema)
 getAvroOf ty0 = go ty0
  where
  env = S.buildTypeEnvironment envFail ty0
  envFail t = fail $ "Named type not in schema: " <> show t
 
- go :: Type -> Get (T.Value Type)
+ go :: Schema -> Get (T.Value Schema)
  go ty =
   case ty of
     Null    -> return T.Null
@@ -77,7 +77,7 @@ getAvroOf ty0 = go ty0
           Just t  -> T.Union ts t <$> go t
     Fixed {..} -> T.Fixed ty <$> G.getByteString (fromIntegral size)
 
- getKVBlocks :: Type -> Get [[(Text,T.Value Type)]]
+ getKVBlocks :: Schema -> Get [[(Text,T.Value Schema)]]
  getKVBlocks t =
   do blockLength <- abs <$> getLong
      if blockLength == 0
@@ -86,7 +86,7 @@ getAvroOf ty0 = go ty0
               (vs:) <$> getKVBlocks t
  {-# INLINE getKVBlocks #-}
 
- getBlocksOf :: Type -> Get [[T.Value Type]]
+ getBlocksOf :: Schema -> Get [[T.Value Schema]]
  getBlocksOf t =
   do blockLength <- abs <$> getLong
      if blockLength == 0

--- a/src/Data/Avro/Deriving.hs
+++ b/src/Data/Avro/Deriving.hs
@@ -488,7 +488,7 @@ genType opts (S.Fixed n _ s) = do
   sequenceA [genNewtype dname]
 genType _ _ = pure []
 
-mkFieldTypeName :: NamespaceBehavior -> S.Type -> Q TH.Type
+mkFieldTypeName :: NamespaceBehavior -> S.Schema -> Q TH.Type
 mkFieldTypeName namespaceBehavior = \case
   S.Boolean          -> [t| Bool |]
   S.Long             -> [t| Int64 |]

--- a/src/Data/Avro/Deriving/Lift.hs
+++ b/src/Data/Avro/Deriving/Lift.hs
@@ -34,4 +34,4 @@ deriving instance Lift f => Lift (Avro.Value f)
 deriving instance Lift Schema.Field
 deriving instance Lift Schema.Order
 deriving instance Lift Schema.TypeName
-deriving instance Lift Schema.Type
+deriving instance Lift Schema.Schema

--- a/src/Data/Avro/Deriving/NormSchema.hs
+++ b/src/Data/Avro/Deriving/NormSchema.hs
@@ -28,7 +28,7 @@ extractDerivables s = flip evalState state . normSchema . snd <$> rawRecs
     rawRecs = getTypes s
     state = M.fromList rawRecs
 
-getTypes :: Type -> [(TypeName, Type)]
+getTypes :: Schema -> [(TypeName, Schema)]
 getTypes rec = case rec of
   r@Record{name, fields} -> (name,r) : (fields >>= (getTypes . fldType))
   Array t                -> getTypes t

--- a/src/Data/Avro/EitherN.hs
+++ b/src/Data/Avro/EitherN.hs
@@ -114,24 +114,24 @@ instance Bitraversable (Either5 a b c) where
   bitraverse _ g (E5_5 a) = E5_5 <$> g a
 
 instance (HasAvroSchema a, HasAvroSchema b, HasAvroSchema c) => HasAvroSchema (Either3 a b c) where
-  schema = Tagged $ mkUnion (untag (schema :: Tagged a Type) :| [
-                             untag (schema :: Tagged b Type),
-                             untag (schema :: Tagged c Type)
+  schema = Tagged $ mkUnion (untag (schema :: Tagged a Schema) :| [
+                             untag (schema :: Tagged b Schema),
+                             untag (schema :: Tagged c Schema)
                             ])
 
 instance (HasAvroSchema a, HasAvroSchema b, HasAvroSchema c, HasAvroSchema d) => HasAvroSchema (Either4 a b c d) where
-  schema = Tagged $ mkUnion (untag (schema :: Tagged a Type) :| [
-                             untag (schema :: Tagged b Type),
-                             untag (schema :: Tagged c Type),
-                             untag (schema :: Tagged d Type)
+  schema = Tagged $ mkUnion (untag (schema :: Tagged a Schema) :| [
+                             untag (schema :: Tagged b Schema),
+                             untag (schema :: Tagged c Schema),
+                             untag (schema :: Tagged d Schema)
                             ])
 
 instance (HasAvroSchema a, HasAvroSchema b, HasAvroSchema c, HasAvroSchema d, HasAvroSchema e) => HasAvroSchema (Either5 a b c d e) where
-  schema = Tagged $ mkUnion (untag (schema :: Tagged a Type) :| [
-                             untag (schema :: Tagged b Type),
-                             untag (schema :: Tagged c Type),
-                             untag (schema :: Tagged d Type),
-                             untag (schema :: Tagged e Type)
+  schema = Tagged $ mkUnion (untag (schema :: Tagged a Schema) :| [
+                             untag (schema :: Tagged b Schema),
+                             untag (schema :: Tagged c Schema),
+                             untag (schema :: Tagged d Schema),
+                             untag (schema :: Tagged e Schema)
                             ])
 
 instance (FromAvro a, FromAvro b, FromAvro c) => FromAvro (Either3 a b c) where
@@ -140,9 +140,9 @@ instance (FromAvro a, FromAvro b, FromAvro c) => FromAvro (Either3 a b c) where
     | matches branch schemaB = E3_2 <$> fromAvro x
     | matches branch schemaC = E3_3 <$> fromAvro x
     | otherwise              = badValue e "Either3"
-    where Tagged schemaA = schema :: Tagged a Type
-          Tagged schemaB = schema :: Tagged b Type
-          Tagged schemaC = schema :: Tagged c Type
+    where Tagged schemaA = schema :: Tagged a Schema
+          Tagged schemaB = schema :: Tagged b Schema
+          Tagged schemaC = schema :: Tagged c Schema
   fromAvro x = badValue x "Either3"
 
 instance (FromAvro a, FromAvro b, FromAvro c, FromAvro d) => FromAvro (Either4 a b c d) where
@@ -152,10 +152,10 @@ instance (FromAvro a, FromAvro b, FromAvro c, FromAvro d) => FromAvro (Either4 a
     | matches branch schemaC = E4_3 <$> fromAvro x
     | matches branch schemaD = E4_4 <$> fromAvro x
     | otherwise              = badValue e "Either4"
-    where Tagged schemaA = schema :: Tagged a Type
-          Tagged schemaB = schema :: Tagged b Type
-          Tagged schemaC = schema :: Tagged c Type
-          Tagged schemaD = schema :: Tagged d Type
+    where Tagged schemaA = schema :: Tagged a Schema
+          Tagged schemaB = schema :: Tagged b Schema
+          Tagged schemaC = schema :: Tagged c Schema
+          Tagged schemaD = schema :: Tagged d Schema
   fromAvro x = badValue x "Either4"
 
 instance (FromAvro a, FromAvro b, FromAvro c, FromAvro d, FromAvro e) => FromAvro (Either5 a b c d e) where
@@ -166,11 +166,11 @@ instance (FromAvro a, FromAvro b, FromAvro c, FromAvro d, FromAvro e) => FromAvr
     | matches branch schemaD = E5_4 <$> fromAvro x
     | matches branch schemaE = E5_5 <$> fromAvro x
     | otherwise              = badValue e "Either5"
-    where Tagged schemaA = schema :: Tagged a Type
-          Tagged schemaB = schema :: Tagged b Type
-          Tagged schemaC = schema :: Tagged c Type
-          Tagged schemaD = schema :: Tagged d Type
-          Tagged schemaE = schema :: Tagged e Type
+    where Tagged schemaA = schema :: Tagged a Schema
+          Tagged schemaB = schema :: Tagged b Schema
+          Tagged schemaC = schema :: Tagged c Schema
+          Tagged schemaD = schema :: Tagged d Schema
+          Tagged schemaE = schema :: Tagged e Schema
   fromAvro x = badValue x "Either5"
 
 instance (FromLazyAvro a, FromLazyAvro b, FromLazyAvro c) => FromLazyAvro (Either3 a b c) where
@@ -179,9 +179,9 @@ instance (FromLazyAvro a, FromLazyAvro b, FromLazyAvro c) => FromLazyAvro (Eithe
     | matches branch schemaB = E3_2 <$> fromLazyAvro x
     | matches branch schemaC = E3_3 <$> fromLazyAvro x
     | otherwise              = badValue e "Either3"
-    where Tagged schemaA = schema :: Tagged a Type
-          Tagged schemaB = schema :: Tagged b Type
-          Tagged schemaC = schema :: Tagged c Type
+    where Tagged schemaA = schema :: Tagged a Schema
+          Tagged schemaB = schema :: Tagged b Schema
+          Tagged schemaC = schema :: Tagged c Schema
   fromLazyAvro x = badValue x "Either3"
 
 instance (FromLazyAvro a, FromLazyAvro b, FromLazyAvro c, FromLazyAvro d) => FromLazyAvro (Either4 a b c d) where
@@ -191,10 +191,10 @@ instance (FromLazyAvro a, FromLazyAvro b, FromLazyAvro c, FromLazyAvro d) => Fro
     | matches branch schemaC = E4_3 <$> fromLazyAvro x
     | matches branch schemaD = E4_4 <$> fromLazyAvro x
     | otherwise              = badValue e "Either4"
-    where Tagged schemaA = schema :: Tagged a Type
-          Tagged schemaB = schema :: Tagged b Type
-          Tagged schemaC = schema :: Tagged c Type
-          Tagged schemaD = schema :: Tagged d Type
+    where Tagged schemaA = schema :: Tagged a Schema
+          Tagged schemaB = schema :: Tagged b Schema
+          Tagged schemaC = schema :: Tagged c Schema
+          Tagged schemaD = schema :: Tagged d Schema
   fromLazyAvro x = badValue x "Either4"
 
 instance (FromLazyAvro a, FromLazyAvro b, FromLazyAvro c, FromLazyAvro d, FromLazyAvro e) => FromLazyAvro (Either5 a b c d e) where
@@ -205,11 +205,11 @@ instance (FromLazyAvro a, FromLazyAvro b, FromLazyAvro c, FromLazyAvro d, FromLa
     | matches branch schemaD = E5_4 <$> fromLazyAvro x
     | matches branch schemaE = E5_5 <$> fromLazyAvro x
     | otherwise              = badValue e "Either5"
-    where Tagged schemaA = schema :: Tagged a Type
-          Tagged schemaB = schema :: Tagged b Type
-          Tagged schemaC = schema :: Tagged c Type
-          Tagged schemaD = schema :: Tagged d Type
-          Tagged schemaE = schema :: Tagged e Type
+    where Tagged schemaA = schema :: Tagged a Schema
+          Tagged schemaB = schema :: Tagged b Schema
+          Tagged schemaC = schema :: Tagged c Schema
+          Tagged schemaD = schema :: Tagged d Schema
+          Tagged schemaE = schema :: Tagged e Schema
   fromLazyAvro x = badValue x "Either5"
 
 instance (ToAvro a, ToAvro b, ToAvro c) => ToAvro (Either3 a b c) where

--- a/src/Data/Avro/Encode.hs
+++ b/src/Data/Avro/Encode.hs
@@ -164,13 +164,13 @@ putAvro = fst . runAvro . avro
 getSchema :: forall a. EncodeAvro a => a -> Schema
 getSchema = snd . runAvro . avro
 
-getType :: EncodeAvro a => Proxy a -> Type
+getType :: EncodeAvro a => Proxy a -> Schema
 getType = getSchema . (asProxyTypeOf undefined)
 -- N.B. ^^^ Local knowledge that 'fst' won't be used,
 -- so the bottom of 'undefined' will not escape so long as schema creation
 -- remains lazy in the argument.
 
-newtype AvroM = AvroM { runAvro :: (Builder,Type) }
+newtype AvroM = AvroM { runAvro :: (Builder, Schema) }
 
 class EncodeAvro a where
   avro :: a -> AvroM
@@ -277,7 +277,7 @@ instance EncodeAvro Bool where
 --------------------------------------------------------------------------------
 --  Common Intermediate Representation Encoding
 
-instance EncodeAvro (T.Value Type) where
+instance EncodeAvro (T.Value Schema) where
   avro v =
     case v of
       T.Null      -> avro ()

--- a/src/Data/Avro/FromAvro.hs
+++ b/src/Data/Avro/FromAvro.hs
@@ -30,9 +30,9 @@ import qualified Data.Vector.Unboxed     as U
 import           Data.Word
 
 class HasAvroSchema a => FromAvro a where
-  fromAvro :: Value Type -> Result a
+  fromAvro :: Value Schema -> Result a
 
-(.:) :: FromAvro a => HashMap.HashMap Text (Value Type) -> Text -> Result a
+(.:) :: FromAvro a => HashMap.HashMap Text (Value Schema) -> Text -> Result a
 (.:) obj key =
   case HashMap.lookup key obj of
     Nothing -> fail $ "Requested field not available: " <> show key
@@ -43,8 +43,8 @@ instance (FromAvro a, FromAvro b) => FromAvro (Either a b) where
     | S.matches branch schemaA = Left  <$> fromAvro x
     | S.matches branch schemaB = Right <$> fromAvro x
     | otherwise              = badValue e "Either"
-    where Tagged schemaA = schema :: Tagged a Type
-          Tagged schemaB = schema :: Tagged b Type
+    where Tagged schemaA = schema :: Tagged a Schema
+          Tagged schemaB = schema :: Tagged b Schema
   fromAvro x = badValue x "Either"
 
 instance FromAvro Bool where

--- a/src/Data/Avro/HasAvroSchema.hs
+++ b/src/Data/Avro/HasAvroSchema.hs
@@ -27,9 +27,9 @@ import qualified Data.Vector.Unboxed  as U
 import           Data.Word
 
 class HasAvroSchema a where
-  schema :: Tagged a Type
+  schema :: Tagged a Schema
 
-schemaOf :: (HasAvroSchema a) => a -> Type
+schemaOf :: (HasAvroSchema a) => a -> Schema
 schemaOf = witness schema
 
 instance HasAvroSchema Word8 where
@@ -84,44 +84,44 @@ instance HasAvroSchema BL.ByteString where
   schema = Tagged S.Bytes
 
 instance (HasAvroSchema a, HasAvroSchema b) => HasAvroSchema (Either a b) where
-  schema = Tagged $ S.Union $ V.fromListN 2 [untag (schema :: Tagged a Type), untag (schema :: Tagged b Type)]
+  schema = Tagged $ S.Union $ V.fromListN 2 [untag (schema :: Tagged a Schema), untag (schema :: Tagged b Schema)]
 
 instance (HasAvroSchema a) => HasAvroSchema (Map.Map Text a) where
-  schema = wrapTag S.Map (schema :: Tagged a Type)
+  schema = wrapTag S.Map (schema :: Tagged a Schema)
 
 instance (HasAvroSchema a) => HasAvroSchema (HashMap.HashMap Text a) where
-  schema = wrapTag S.Map (schema :: Tagged a Type)
+  schema = wrapTag S.Map (schema :: Tagged a Schema)
 
 instance (HasAvroSchema a) => HasAvroSchema (Map.Map TL.Text a) where
-  schema = wrapTag S.Map (schema :: Tagged a Type)
+  schema = wrapTag S.Map (schema :: Tagged a Schema)
 
 instance (HasAvroSchema a) => HasAvroSchema (HashMap.HashMap TL.Text a) where
-  schema = wrapTag S.Map (schema :: Tagged a Type)
+  schema = wrapTag S.Map (schema :: Tagged a Schema)
 
 instance (HasAvroSchema a) => HasAvroSchema (Map.Map String a) where
-  schema = wrapTag S.Map (schema :: Tagged a Type)
+  schema = wrapTag S.Map (schema :: Tagged a Schema)
 
 instance (HasAvroSchema a) => HasAvroSchema (HashMap.HashMap String a) where
-  schema = wrapTag S.Map (schema :: Tagged a Type)
+  schema = wrapTag S.Map (schema :: Tagged a Schema)
 
 instance (HasAvroSchema a) => HasAvroSchema (Maybe a) where
-  schema = Tagged $ mkUnion (S.Null:| [untag (schema :: Tagged a Type)])
+  schema = Tagged $ mkUnion (S.Null:| [untag (schema :: Tagged a Schema)])
 
 instance (HasAvroSchema a) => HasAvroSchema [a] where
-  schema = wrapTag S.Array (schema :: Tagged a Type)
+  schema = wrapTag S.Array (schema :: Tagged a Schema)
 
 instance (HasAvroSchema a, Ix i) => HasAvroSchema (Ar.Array i a) where
-  schema = wrapTag S.Array (schema :: Tagged a Type)
+  schema = wrapTag S.Array (schema :: Tagged a Schema)
 
 instance HasAvroSchema a => HasAvroSchema (V.Vector a) where
-  schema = wrapTag S.Array (schema :: Tagged a Type)
+  schema = wrapTag S.Array (schema :: Tagged a Schema)
 
 instance HasAvroSchema a => HasAvroSchema (U.Vector a) where
-  schema = wrapTag S.Array (schema :: Tagged a Type)
+  schema = wrapTag S.Array (schema :: Tagged a Schema)
 
 instance HasAvroSchema a => HasAvroSchema (S.Set a) where
-  schema = wrapTag S.Array (schema :: Tagged a Type)
+  schema = wrapTag S.Array (schema :: Tagged a Schema)
 
-wrapTag :: (Type -> Type) -> Tagged a Type -> Tagged b Type
+wrapTag :: (Schema -> Schema) -> Tagged a Schema -> Tagged b Schema
 wrapTag f = Tagged . f . untag
 {-# INLINE wrapTag #-}

--- a/src/Data/Avro/Schema.hs
+++ b/src/Data/Avro/Schema.hs
@@ -83,21 +83,12 @@ import           Prelude                as P
 
 import GHC.Generics (Generic)
 
--- | An Avro schema is either
---
--- * A "JSON object in the form @{"type":"typeName" ...}@
---
--- * A "JSON string, naming a defined type" (basic type without free variables)
---
--- * A "JSON array, representing a union"
---
--- N.B. It is possible to create a Haskell value (of 'Schema' type) that is
--- not a valid Avro schema by violating one of the above or one of the
--- conditions called out in 'validateSchema'.
+{-# DEPRECATED Type "Use Schema instead" #-}
 type Type = Schema
 
--- |Avro types are considered either primitive (string, int, etc) or
--- complex/declared (structures, unions etc).
+-- | N.B. It is possible to create a Haskell value (of 'Schema' type) that is
+-- not a valid Avro schema by violating one of the above or one of the
+-- conditions called out in 'validateSchema'.
 data Schema
       =
       -- Basic types

--- a/src/Data/Avro/ToAvro.hs
+++ b/src/Data/Avro/ToAvro.hs
@@ -25,9 +25,9 @@ import qualified Data.Vector.Unboxed     as U
 import           Data.Word
 
 class HasAvroSchema a => ToAvro a where
-  toAvro :: a -> T.Value Type
+  toAvro :: a -> T.Value Schema
 
-(.=)  :: ToAvro a => Text -> a -> (Text,T.Value Type)
+(.=)  :: ToAvro a => Text -> a -> (Text,T.Value Schema)
 (.=) nm val = (nm,toAvro val)
 
 instance ToAvro Bool where

--- a/test/Avro/NormSchemaSpec.hs
+++ b/test/Avro/NormSchemaSpec.hs
@@ -7,7 +7,7 @@ where
 
 import           Data.Avro
 import           Data.Avro.Deriving
-import           Data.Avro.Schema   (Type (..), fields, fldType, mkUnion)
+import           Data.Avro.Schema   (Schema (..), fields, fldType, mkUnion)
 import           Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.Set           as S
 

--- a/test/Avro/ReuseFixedSpec.hs
+++ b/test/Avro/ReuseFixedSpec.hs
@@ -8,7 +8,7 @@ where
 import qualified Data.Aeson           as Aeson
 import           Data.Avro            as Avro
 import           Data.Avro.Deriving
-import           Data.Avro.Schema     (Type (..), fields, fldType, mkUnion)
+import           Data.Avro.Schema     (Schema (..), fields, fldType, mkUnion)
 import           Data.ByteString.Lazy as LBS
 import           Data.List.NonEmpty   (NonEmpty (..))
 import qualified Data.Set             as S


### PR DESCRIPTION
`Schema` used to be type synonym for `Type`:

```haskell
type Schema = Type
```

This caused some confusion because `Type` and `Schema` were used interchangeably everywhere in code.

This PR deprecates `Type` and uses `Schema` everywhere.