### PR TITLE
[WIP] Annotations

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,7 +5,7 @@
       "label": "Build",
       "type": "shell",
       "command": "bash",
-      "args": ["-lc", "cabal new-build && echo 'Done'"],
+      "args": ["-lc", "cabal v2-build && echo 'Done'"],
       "group": {
         "kind": "build",
         "isDefault": true
@@ -37,7 +37,7 @@
       "label": "Test",
       "type": "shell",
       "command": "bash",
-      "args": ["-lc", "cabal new-test && echo 'Done'"],
+      "args": ["-lc", "cabal v2-test --enable-tests && echo 'Done'"],
       "group": {
         "kind": "test",
         "isDefault": true

--- a/avro.cabal
+++ b/avro.cabal
@@ -139,6 +139,7 @@ library
                         Data.Avro.HasAvroSchema
                         Data.Avro.JSON
                         Data.Avro.Schema
+                        Data.Avro.Schema.Deconflict
                         Data.Avro.ToAvro
                         Data.Avro.Types
                         Data.Avro.Types.Value

--- a/bench/Bench/Time.hs
+++ b/bench/Bench/Time.hs
@@ -60,9 +60,9 @@ encodeArray = env randoms $ \ ~(bools, ints, longs, records) ->
           , ("l", Value.Long long)
           ]
         recordSchema = Schema.Record "Rec" [] Nothing Nothing
-          [ Schema.Field "b" [] Nothing Nothing Schema.Boolean Nothing
-          , Schema.Field "i" [] Nothing Nothing Schema.Int Nothing
-          , Schema.Field "l" [] Nothing Nothing Schema.Long Nothing
+          [ Schema.Field "b" [] Nothing Nothing Schema.AsIs Schema.Boolean Nothing
+          , Schema.Field "i" [] Nothing Nothing Schema.AsIs Schema.Int Nothing
+          , Schema.Field "l" [] Nothing Nothing Schema.AsIs Schema.Long Nothing
           ]
 
 encodeAvro :: Value Schema -> LBS.ByteString
@@ -106,9 +106,9 @@ decodeArray = env randoms $ \ ~(bools, ints, longs, records) ->
           , ("l", Value.Long long)
           ]
         recordSchema = Schema.Record "Rec" [] Nothing Nothing
-          [ Schema.Field "b" [] Nothing Nothing Schema.Boolean Nothing
-          , Schema.Field "i" [] Nothing Nothing Schema.Int Nothing
-          , Schema.Field "l" [] Nothing Nothing Schema.Long Nothing
+          [ Schema.Field "b" [] Nothing Nothing Schema.AsIs Schema.Boolean Nothing
+          , Schema.Field "i" [] Nothing Nothing Schema.AsIs Schema.Int Nothing
+          , Schema.Field "l" [] Nothing Nothing Schema.AsIs Schema.Long Nothing
           ]
 
 decodeAvro :: Schema -> LBS.ByteString -> Value Schema

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,39 @@
+let 
+  vscode-overlay = self: super: {
+    vscode-with-extensions = super.vscode-with-extensions.override {
+      vscodeExtensions = with super.vscode-extensions; [
+        bbenoist.Nix
+      ] ++ super.vscode-utils.extensionsFromVscodeMarketplace [
+        {
+          name = "ghcide";
+          publisher = "DigitalAssetHoldingsLLC";
+          version = "0.0.2";
+          sha256 = "02gla0g11qcgd6sjvkiazzk3fq104b38skqrs6hvxcv2fzvm9zwf";
+        }
+        {
+            name = "language-haskell";
+            publisher = "justusadam";
+            version = "2.6.0";
+            sha256 = "1891pg4x5qkh151pylvn93c4plqw6vgasa4g40jbma5xzq8pygr4";
+        }
+      ];
+    };
+  };
+in
+  with import <nixpkgs> {
+    overlays = [ vscode-overlay ];
+  };
+
+  pkgs.mkShell {
+    buildInputs = with pkgs; [
+      zlib
+      ghc
+      cabal-install
+      vscode-with-extensions
+    ];
+
+    shellHook = ''
+      PATH=~/.cabal/bin:$PATH
+      LD_LIBRARY_PATH=${pkgs.zlib}/lib/:$LD_LIBRARY_PATH
+    '';
+  }

--- a/src/Data/Avro.hs
+++ b/src/Data/Avro.hs
@@ -131,11 +131,9 @@ decodeContainerWithSchema readerSchema bs =
   case D.decodeContainer bs of
     Right (writerSchema,val) ->
       let
-        writerSchema' = S.expandNamedTypes writerSchema
-        readerSchema' = S.expandNamedTypes readerSchema
         err e = error $ "Could not deconflict reader and writer schema." <> e
         dec x =
-          case C.deconflictNoResolve writerSchema' readerSchema' x of
+          case C.deconflict writerSchema readerSchema x of
             Left e   -> err e
             Right v  -> case fromAvro v of
                           Success x -> x

--- a/src/Data/Avro/Decode/Lazy.hs
+++ b/src/Data/Avro/Decode/Lazy.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections       #-}
+{-# LANGUAGE TypeApplications    #-}
 
 module Data.Avro.Decode.Lazy
   ( decodeAvro
@@ -66,8 +67,8 @@ import           Data.Avro.Zag
 import qualified Data.Avro.Decode.Strict.Internal as DecodeStrict
 
 import Data.Avro.Decode.Get
-import Data.Avro.Decode.Lazy.Convert      (toStrictValue)
-import Data.Avro.Decode.Lazy.Deconflict   as C
+import Data.Avro.Decode.Lazy.Convert      (fromStrictValue, toStrictValue)
+import Data.Avro.Schema.Deconflict   as Dec
 import Data.Avro.Decode.Lazy.FromLazyAvro
 import Data.Avro.FromAvro
 
@@ -124,10 +125,10 @@ decodeContainerWithSchema s bs =
 -- and with the container's writer schema.
 decodeContainerWithSchema' :: FromLazyAvro a => Schema -> BL.ByteString -> Either String [[Either String a]]
 decodeContainerWithSchema' readerSchema bs = do
-  (writerSchema, vals) <- getContainerValues bs
-  pure $ (fmap . fmap) (convertValue writerSchema readerSchema) vals
+  (_, vals) <- getDeconflictedValues bs
+  pure $ (fmap . fmap) (resultToEither . fromLazyAvro) vals
   where
-    convertValue w r v = resultToEither $ fromLazyAvro (C.deconflict w r v)
+    getDeconflictedValues = getContainerValuesWith (getAvroOf . flip deconflict readerSchema)
 
 -- |Decode bytes into a 'Value' as described by Schema.
 decodeAvro :: Schema -> BL.ByteString -> T.LazyValue Schema
@@ -308,9 +309,8 @@ getAvroOf ty0 bs = go ty0 bs
           Right (bs', _, v)  -> go v bs'
 
       Record {..} -> do
-        let getField bs' Field {..} = (fldName,) <$> go fldType bs'
-        let flds = foldl' (\(bs', as) fld -> (:as) <$> getField bs' fld ) (bs, []) fields
-        T.Record ty . HashMap.fromList <$> flds
+        let flds = foldl' (\(bs', as) fld -> (:as) <$> getField fld bs' ) (bs, []) fields
+        T.Record ty . HashMap.fromList . catMaybes <$> flds
 
       Enum {..} ->
         case runGetOrFail getLong bs of
@@ -332,8 +332,25 @@ getAvroOf ty0 bs = go ty0 bs
         case runGetOrFail (G.getByteString (fromIntegral size)) bs of
           Left (bs', _, err) -> (bs', T.Error err)
           Right (bs', _, v)  -> (bs', T.Fixed ty v)
+
+      IntLongCoercion     -> decodeGet @Int32 (T.Long   . fromIntegral) bs
+      IntFloatCoercion    -> decodeGet @Int32 (T.Float  . fromIntegral) bs
+      IntDoubleCoercion   -> decodeGet @Int32 (T.Double . fromIntegral) bs
+      LongFloatCoercion   -> decodeGet @Int64 (T.Float  . fromIntegral) bs
+      LongDoubleCoercion  -> decodeGet @Int64 (T.Double . fromIntegral) bs
+      FloatDoubleCoercion -> decodeGet @Float (T.Double . realToFrac)   bs
+      FreeUnion {..} -> T.Union (V.singleton ty) ty <$> go ty bs
+      Panic {..} -> (fst (go ty bs), T.Error err)
+
+  getField :: Field -> BL.ByteString -> (BL.ByteString, Maybe (Text, T.LazyValue Schema))
+  getField Field{..} bs =
+    case fldStatus of
+      AsIs        -> Just . (fldName,) <$> go fldType bs
+      Ignored     -> (fst (go fldType bs), Nothing)
+      Defaulted v -> (bs, Just (fldName, fromStrictValue v))
 {-# INLINABLE getAvroOf #-}
 
+getKVPair :: (BL.ByteString -> (BL.ByteString, T.LazyValue f)) -> BL.ByteString -> (BL.ByteString, (Text, T.LazyValue f))
 getKVPair getElement bs =
   case runGetOrFail getString bs of
     Left (bs'', _, err) -> (bs'', ("", T.Error err))

--- a/src/Data/Avro/Decode/Lazy.hs
+++ b/src/Data/Avro/Decode/Lazy.hs
@@ -125,11 +125,9 @@ decodeContainerWithSchema s bs =
 decodeContainerWithSchema' :: FromLazyAvro a => Schema -> BL.ByteString -> Either String [[Either String a]]
 decodeContainerWithSchema' readerSchema bs = do
   (writerSchema, vals) <- getContainerValues bs
-  let writerSchema' = S.expandNamedTypes writerSchema
-  let readerSchema' = S.expandNamedTypes readerSchema
-  pure $ (fmap . fmap) (convertValue writerSchema' readerSchema') vals
+  pure $ (fmap . fmap) (convertValue writerSchema readerSchema) vals
   where
-    convertValue w r v = resultToEither $ fromLazyAvro (C.deconflictNoResolve w r v)
+    convertValue w r v = resultToEither $ fromLazyAvro (C.deconflict w r v)
 
 -- |Decode bytes into a 'Value' as described by Schema.
 decodeAvro :: Schema -> BL.ByteString -> T.LazyValue Schema

--- a/src/Data/Avro/Decode/Lazy/Deconflict.hs
+++ b/src/Data/Avro/Decode/Lazy/Deconflict.hs
@@ -91,12 +91,12 @@ startDeconflict shouldExpandNames writerSchema readerSchema = go writerSchema re
     go aTy bTy val | aTy == bTy = val
     go eTy dTy val =
       case val of
-        T.Int i32  | dTy == S.Long   -> T.Long   (fromIntegral i32)
-                   | dTy == S.Float  -> T.Float  (fromIntegral i32)
-                   | dTy == S.Double -> T.Double (fromIntegral i32)
-        T.Long i64 | dTy == S.Float  -> T.Float  (fromIntegral i64)
-                   | dTy == S.Double -> T.Double (fromIntegral i64)
-        T.Float f  | dTy == S.Double -> T.Double (realToFrac f)
+        T.Int i32  | dTy == S.Long ReadAsIs   -> T.Long   (fromIntegral i32)
+                   | dTy == S.Float ReadAsIs  -> T.Float  (fromIntegral i32)
+                   | dTy == S.Double ReadAsIs -> T.Double (fromIntegral i32)
+        T.Long i64 | dTy == S.Float ReadAsIs  -> T.Float  (fromIntegral i64)
+                   | dTy == S.Double ReadAsIs -> T.Double (fromIntegral i64)
+        T.Float f  | dTy == S.Double ReadAsIs -> T.Double (realToFrac f)
         T.String s | dTy == S.Bytes  -> T.Bytes  (Text.encodeUtf8 s)
         T.Bytes bs | dTy == S.String -> T.String (Text.decodeUtf8 bs)
         _                            -> T.Error $ "Can not resolve differing writer and reader schemas: " ++ show (eTy, dTy)

--- a/src/Data/Avro/Decode/Lazy/Deconflict.hs
+++ b/src/Data/Avro/Decode/Lazy/Deconflict.hs
@@ -22,6 +22,8 @@ import qualified Data.Text.Encoding              as Text
 import           Data.Vector                     (Vector)
 import qualified Data.Vector                     as V
 
+{-# DEPRECATED deconflict, deconflictNoResolve "Use Data.Avro.Schema.Deconflict.deconflict or Data.Avro.Decode.Lazy.decodeContainerWithSchema instead." #-}
+
 type Deconflicter =
      Schema        -- ^ Writer schema
   -> Schema        -- ^ Reader schema
@@ -134,7 +136,7 @@ deconflictRecord go writerSchema readerSchema (T.Record ty fldVals)  =
 --  3) If there is no default, fail.
 --
 -- XXX: Consider aliases in the writer schema, use those to retry on failed lookup.
-deconflictFields :: Deconflicter -> HashMap Text (T.LazyValue Schema) -> [Field] -> Field -> (Text,T.LazyValue Schema)
+deconflictFields :: Deconflicter -> HashMap Text (T.LazyValue Schema) -> [Field] -> Field -> (Text, T.LazyValue Schema)
 deconflictFields go hm writerFields readerField =
   let
     mbWriterField = findField readerField writerFields

--- a/src/Data/Avro/Decode/Lazy/Deconflict.hs
+++ b/src/Data/Avro/Decode/Lazy/Deconflict.hs
@@ -22,6 +22,12 @@ import qualified Data.Text.Encoding              as Text
 import           Data.Vector                     (Vector)
 import qualified Data.Vector                     as V
 
+type Deconflicter =
+     Schema        -- ^ Writer schema
+  -> Schema        -- ^ Reader schema
+  -> T.LazyValue Schema
+  -> T.LazyValue Schema
+
 -- | @deconflict writer reader val@ will convert a value that was
 -- encoded/decoded with the writer's schema into the form specified by the
 -- reader's schema.
@@ -33,8 +39,7 @@ deconflict :: Schema        -- ^ Writer schema
            -> Schema        -- ^ Reader schema
            -> T.LazyValue Schema
            -> T.LazyValue Schema
-deconflict writerSchema readerSchema =
-  deconflictNoResolve (S.expandNamedTypes writerSchema) (S.expandNamedTypes readerSchema)
+deconflict = startDeconflict True
 
 -- | @deconflict writer reader val@ will convert a value that was
 -- encoded/decoded with the writer's schema into the form specified by the
@@ -50,15 +55,16 @@ deconflictNoResolve :: Schema         -- ^ Writer schema
                     -> Schema         -- ^ Reader schema
                     -> T.LazyValue Schema
                     -> T.LazyValue Schema
-deconflictNoResolve writerSchema readerSchema =
-  deconflictValue writerSchema readerSchema
+deconflictNoResolve = startDeconflict False
 
-deconflictValue :: Schema -> Schema -> T.LazyValue Schema -> T.LazyValue Schema
-deconflictValue writerSchema readerSchema v
-  | writerSchema == readerSchema    = v
-  | otherwise = go writerSchema readerSchema v
+startDeconflict :: Bool -> Deconflicter
+startDeconflict shouldExpandNames writerSchema readerSchema = go writerSchema readerSchema
   where
-    go :: Schema -> Schema -> T.LazyValue Schema -> T.LazyValue Schema
+    aEnv = S.buildTypeEnvironment (const $ Left "Bad Schema") writerSchema
+    bEnv = S.buildTypeEnvironment (const $ Left "Bad Schema") readerSchema
+    go :: Deconflicter
+    go aTy bTy val
+        | not shouldExpandNames && aTy == bTy = val
     go _ _ val@(T.Error _) = val
     go (S.Array aTy) (S.Array bTy) (T.Array vec) =
         T.Array $ fmap (go aTy bTy) vec
@@ -69,22 +75,27 @@ deconflictValue writerSchema readerSchema v
     go a@S.Fixed {} b@S.Fixed {} val
         | name a == name b && size a == size b = val
     go a@S.Record {} b@S.Record {} val
-        | name a == name b = deconflictRecord a b val
+        | name a == name b = deconflictRecord go a b val
     go (S.Union xs) (S.Union ys) (T.Union _ tyVal val) =
-        withSchemaIn tyVal xs $ \sch -> deconflictReaderUnion sch ys val
+        withSchemaIn tyVal xs $ \sch -> deconflictReaderUnion go sch ys val
     go nonUnion (S.Union ys) val =
-        deconflictReaderUnion nonUnion ys val
+        deconflictReaderUnion go nonUnion ys val
     go (S.Union xs) nonUnion (T.Union _ tyVal val) =
-        withSchemaIn tyVal xs $ \sch -> deconflictValue sch nonUnion val
+        withSchemaIn tyVal xs $ \sch -> go sch nonUnion val
+    go (S.NamedType t) bTy val =
+      either T.Error (\aTy -> go aTy bTy val) $ aEnv t
+    go aTy (S.NamedType t) val =
+      either T.Error (\bTy -> go aTy bTy val) $ bEnv t
+    go aTy bTy val | aTy == bTy = val
     go eTy dTy val =
       case val of
         T.Int i32  | dTy == S.Long   -> T.Long   (fromIntegral i32)
                    | dTy == S.Float  -> T.Float  (fromIntegral i32)
                    | dTy == S.Double -> T.Double (fromIntegral i32)
-        T.Long i64 | dTy == S.Float  -> T.Float (fromIntegral i64)
+        T.Long i64 | dTy == S.Float  -> T.Float  (fromIntegral i64)
                    | dTy == S.Double -> T.Double (fromIntegral i64)
         T.Float f  | dTy == S.Double -> T.Double (realToFrac f)
-        T.String s | dTy == S.Bytes  -> T.Bytes (Text.encodeUtf8 s)
+        T.String s | dTy == S.Bytes  -> T.Bytes  (Text.encodeUtf8 s)
         T.Bytes bs | dTy == S.String -> T.String (Text.decodeUtf8 bs)
         _                            -> T.Error $ "Can not resolve differing writer and reader schemas: " ++ show (eTy, dTy)
 
@@ -104,32 +115,32 @@ withSchemaIn schema schemas f =
     Nothing    -> T.Error $ "Incorrect payload: union " <> (show . Foldable.toList $ typeName <$> schemas) <> " does not contain schema " <> Text.unpack (typeName schema)
     Just found -> f found
 
-deconflictReaderUnion :: Schema -> Vector Schema -> T.LazyValue Schema -> T.LazyValue Schema
-deconflictReaderUnion valueType unionTypes val =
+deconflictReaderUnion :: Deconflicter -> Schema -> Vector Schema -> T.LazyValue Schema -> T.LazyValue Schema
+deconflictReaderUnion go valueType unionTypes val =
   let hdl [] = T.Error $ "No corresponding union value for " <> Text.unpack (typeName valueType)
       hdl (d:rest) =
-            case deconflictValue valueType d val of
+            case go valueType d val of
               T.Error _ -> hdl rest
               v         -> T.Union unionTypes d v
   in hdl (V.toList unionTypes)
 
-deconflictRecord :: Schema -> Schema -> T.LazyValue Schema -> T.LazyValue Schema
-deconflictRecord writerSchema readerSchema (T.Record ty fldVals)  =
-  T.Record readerSchema . HashMap.fromList $ fmap (deconflictFields fldVals (fields writerSchema)) (fields readerSchema)
+deconflictRecord :: Deconflicter -> Schema -> Schema -> T.LazyValue Schema -> T.LazyValue Schema
+deconflictRecord go writerSchema readerSchema (T.Record ty fldVals)  =
+  T.Record readerSchema . HashMap.fromList $ fmap (deconflictFields go fldVals (fields writerSchema)) (fields readerSchema)
 
 -- For each field of the decoders, lookup the field in the hash map
---  1) If the field exists, call 'deconflictValue'
+--  1) If the field exists, call the given deconflicting function
 --  2) If the field is missing use the reader's default
 --  3) If there is no default, fail.
 --
 -- XXX: Consider aliases in the writer schema, use those to retry on failed lookup.
-deconflictFields :: HashMap Text (T.LazyValue Schema) -> [Field] -> Field -> (Text,T.LazyValue Schema)
-deconflictFields hm writerFields readerField =
+deconflictFields :: Deconflicter -> HashMap Text (T.LazyValue Schema) -> [Field] -> Field -> (Text,T.LazyValue Schema)
+deconflictFields go hm writerFields readerField =
   let
     mbWriterField = findField readerField writerFields
     mbValue = HashMap.lookup (fldName readerField) hm
   in case (mbWriterField, mbValue, fldDefault readerField) of
-    (Just w, Just x,_)  -> (fldName readerField, deconflictValue (fldType w) (fldType readerField) x)
+    (Just w, Just x,_)  -> (fldName readerField, go (fldType w) (fldType readerField) x)
     (_, Just x,_)       -> (fldName readerField, x)
     (_, _,Just def)     -> (fldName readerField, fromStrictValue def)
     (_,Nothing,Nothing) -> (fldName readerField, T.Error ("No field and no default for " ++ show (fldName readerField)))

--- a/src/Data/Avro/Decode/Lazy/FromLazyAvro.hs
+++ b/src/Data/Avro/Decode/Lazy/FromLazyAvro.hs
@@ -91,8 +91,8 @@ instance FromLazyAvro Float where
 
 instance FromLazyAvro a => FromLazyAvro (Maybe a) where
   fromLazyAvro (T.Union ts _ v) = case (V.toList ts, v) of
-    ([S.Null, _], T.Null) -> pure Nothing
-    ([S.Null, _], v')     -> Just <$> fromLazyAvro v'
+    ([S.Null _, _], T.Null) -> pure Nothing
+    ([S.Null _, _], v')     -> Just <$> fromLazyAvro v'
     _                     -> badValue v "Maybe a"
   fromLazyAvro v                = badValue v "Maybe a"
 

--- a/src/Data/Avro/Decode/Strict/Internal.hs
+++ b/src/Data/Avro/Decode/Strict/Internal.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections       #-}
+{-# LANGUAGE TypeApplications    #-}
 module Data.Avro.Decode.Strict.Internal
 where
 
@@ -64,8 +65,7 @@ getAvroOf ty0 = go ty0
          return $ T.Map (HashMap.fromList $ mconcat kvs)
     NamedType tn -> env tn >>= go
     Record {..} ->
-      do let getField Field {..} = (fldName,) <$> go fldType
-         T.Record ty . HashMap.fromList <$> mapM getField fields
+      T.Record ty . HashMap.fromList . catMaybes <$> mapM getField fields
     Enum {..} ->
       do i <- getLong
          let sym = fromMaybe "" (symbols V.!? (fromIntegral i)) -- empty string for 'missing' symbols (alternative is an error or exception)
@@ -76,6 +76,21 @@ getAvroOf ty0 = go ty0
           Nothing -> fail $ "Decoded Avro tag is outside the expected range for a Union. Tag: " <> show i <> " union of: " <> show (V.map typeName ts)
           Just t  -> T.Union ts t <$> go t
     Fixed {..} -> T.Fixed ty <$> G.getByteString (fromIntegral size)
+    IntLongCoercion     -> T.Long   . fromIntegral <$> getAvro @Int32
+    IntFloatCoercion    -> T.Float  . fromIntegral <$> getAvro @Int32
+    IntDoubleCoercion   -> T.Double . fromIntegral <$> getAvro @Int32
+    LongFloatCoercion   -> T.Float  . fromIntegral <$> getAvro @Int64
+    LongDoubleCoercion  -> T.Double . fromIntegral <$> getAvro @Int64
+    FloatDoubleCoercion -> T.Double . realToFrac   <$> getAvro @Float
+    FreeUnion ty -> T.Union (V.singleton ty) ty <$> go ty
+    Panic {..} -> fail err
+
+ getField :: Field -> Get (Maybe (Text, T.Value Schema))
+ getField Field{..} =
+  case fldStatus of
+    AsIs        -> Just . (fldName,) <$> go fldType
+    Ignored     -> go fldType >> pure Nothing
+    Defaulted v -> pure $ Just (fldName, v)
 
  getKVBlocks :: Schema -> Get [[(Text,T.Value Schema)]]
  getKVBlocks t =

--- a/src/Data/Avro/Deconflict.hs
+++ b/src/Data/Avro/Deconflict.hs
@@ -22,6 +22,8 @@ import qualified Data.Text.Encoding  as Text
 import           Data.Vector         (Vector)
 import qualified Data.Vector         as V
 
+{-# DEPRECATED deconflict, deconflictNoResolve "Use Data.Avro.Schema.Deconflict.deconflict or Data.Avro.decodeContainerWithSchema instead." #-}
+
 type Deconflicter =
      Schema        -- ^ Writer schema
   -> Schema        -- ^ Reader schema

--- a/src/Data/Avro/Deconflict.hs
+++ b/src/Data/Avro/Deconflict.hs
@@ -93,12 +93,12 @@ startDeconflict shouldExpandNames writerSchema readerSchema = go writerSchema re
   go aTy bTy val | aTy == bTy = Right val
   go eTy dTy val =
     case val of
-      T.Int i32  | dTy == S.Long   -> Right $ T.Long   (fromIntegral i32)
-                 | dTy == S.Float  -> Right $ T.Float  (fromIntegral i32)
-                 | dTy == S.Double -> Right $ T.Double (fromIntegral i32)
-      T.Long i64 | dTy == S.Float  -> Right $ T.Float  (fromIntegral i64)
-                 | dTy == S.Double -> Right $ T.Double (fromIntegral i64)
-      T.Float f  | dTy == S.Double -> Right $ T.Double (realToFrac f)
+      T.Int i32  | dTy == S.Long ReadAsIs  -> Right $ T.Long   (fromIntegral i32)
+                 | dTy == S.Float ReadAsIs -> Right $ T.Float  (fromIntegral i32)
+                 | dTy == S.Double ReadAsIs -> Right $ T.Double (fromIntegral i32)
+      T.Long i64 | dTy == S.Float ReadAsIs  -> Right $ T.Float  (fromIntegral i64)
+                 | dTy == S.Double ReadAsIs -> Right $ T.Double (fromIntegral i64)
+      T.Float f  | dTy == S.Double ReadAsIs -> Right $ T.Double (realToFrac f)
       T.String s | dTy == S.Bytes  -> Right $ T.Bytes  (Text.encodeUtf8 s)
       T.Bytes bs | dTy == S.String -> Right $ T.String (Text.decodeUtf8 bs)
       _                            -> Left $ "Can not resolve differing writer and reader schemas: " ++ show (eTy, dTy)

--- a/src/Data/Avro/Deconflict.hs
+++ b/src/Data/Avro/Deconflict.hs
@@ -22,6 +22,12 @@ import qualified Data.Text.Encoding  as Text
 import           Data.Vector         (Vector)
 import qualified Data.Vector         as V
 
+type Deconflicter =
+     Schema        -- ^ Writer schema
+  -> Schema        -- ^ Reader schema
+  -> T.Value Schema
+  -> Either String (T.Value Schema)
+
 -- | @deconflict writer reader val@ will convert a value that was
 -- encoded/decoded with the writer's schema into the form specified by the
 -- reader's schema.
@@ -33,8 +39,7 @@ deconflict :: Schema        -- ^ Writer schema
            -> Schema        -- ^ Reader schema
            -> T.Value Schema
            -> Either String (T.Value Schema)
-deconflict writerSchema readerSchema =
-  deconflictNoResolve (S.expandNamedTypes writerSchema) (S.expandNamedTypes readerSchema)
+deconflict = startDeconflict True
 
 -- | @deconflict writer reader val@ will convert a value that was
 -- encoded/decoded with the writer's schema into the form specified by the
@@ -50,18 +55,17 @@ deconflictNoResolve :: Schema         -- ^ Writer schema
                     -> Schema         -- ^ Reader schema
                     -> T.Value Schema
                     -> Either String (T.Value Schema)
-deconflictNoResolve writerSchema readerSchema =
-  deconflictValue writerSchema readerSchema
+deconflictNoResolve = startDeconflict False
 
-deconflictValue :: Schema
-              -> Schema
-              -> T.Value Schema
-              -> Either String (T.Value Schema)
-deconflictValue writerSchema readerSchema v
-  | writerSchema == readerSchema    = Right v
-  | otherwise = go writerSchema readerSchema v
+
+startDeconflict :: Bool -> Deconflicter
+startDeconflict shouldExpandNames writerSchema readerSchema = go writerSchema readerSchema
   where
-  go :: Schema -> Schema -> T.Value Schema -> Either String (T.Value Schema)
+  aEnv = S.buildTypeEnvironment (const $ Left "Bad Schema") writerSchema
+  bEnv = S.buildTypeEnvironment (const $ Left "Bad Schema") readerSchema
+  go :: Deconflicter
+  go aTy bTy val
+    | not shouldExpandNames && aTy == bTy = Right val
   go (S.Array aTy) (S.Array bTy) (T.Array vec) =
        T.Array <$> mapM (go aTy bTy) vec
   go (S.Map aTy) (S.Map bTy) (T.Map mp)    =
@@ -71,22 +75,29 @@ deconflictValue writerSchema readerSchema v
   go a@S.Fixed {} b@S.Fixed {} val
        | name a == name b && size a == size b = Right val
   go a@S.Record {} b@S.Record {} val
-       | name a == name b = deconflictRecord a b val
+       | name a == name b = deconflictRecord go a b val
   go (S.Union xs) (S.Union ys) (T.Union _ tyVal val) =
-       withSchemaIn tyVal xs $ \sch -> deconflictReaderUnion sch ys val
+       withSchemaIn tyVal xs $ \sch -> deconflictReaderUnion go sch ys val
   go nonUnion (S.Union ys) val =
-       deconflictReaderUnion nonUnion ys val
+       deconflictReaderUnion go nonUnion ys val
   go (S.Union xs) nonUnion (T.Union _ tyVal val) =
-       withSchemaIn tyVal xs $ \sch -> deconflictValue sch nonUnion val
+       withSchemaIn tyVal xs $ \sch -> go sch nonUnion val
+  go (S.NamedType t) bTy val = do
+       aTy <- aEnv t
+       go aTy bTy val
+  go aTy (S.NamedType t) val = do
+       bTy <- bEnv t
+       go aTy bTy val
+  go aTy bTy val | aTy == bTy = Right val
   go eTy dTy val =
     case val of
       T.Int i32  | dTy == S.Long   -> Right $ T.Long   (fromIntegral i32)
                  | dTy == S.Float  -> Right $ T.Float  (fromIntegral i32)
                  | dTy == S.Double -> Right $ T.Double (fromIntegral i32)
-      T.Long i64 | dTy == S.Float  -> Right $ T.Float (fromIntegral i64)
+      T.Long i64 | dTy == S.Float  -> Right $ T.Float  (fromIntegral i64)
                  | dTy == S.Double -> Right $ T.Double (fromIntegral i64)
       T.Float f  | dTy == S.Double -> Right $ T.Double (realToFrac f)
-      T.String s | dTy == S.Bytes  -> Right $ T.Bytes (Text.encodeUtf8 s)
+      T.String s | dTy == S.Bytes  -> Right $ T.Bytes  (Text.encodeUtf8 s)
       T.Bytes bs | dTy == S.String -> Right $ T.String (Text.decodeUtf8 bs)
       _                            -> Left $ "Can not resolve differing writer and reader schemas: " ++ show (eTy, dTy)
 
@@ -106,32 +117,32 @@ withSchemaIn schema schemas f =
     Nothing    -> Left $ "Incorrect payload: union " <> (show . Foldable.toList $ typeName <$> schemas) <> " does not contain schema " <> Text.unpack (typeName schema)
     Just found -> f found
 
-deconflictReaderUnion :: Schema -> Vector Schema -> T.Value Schema -> Either String (T.Value Schema)
-deconflictReaderUnion valueSchema unionTypes val =
+deconflictReaderUnion :: Deconflicter -> Schema -> Vector Schema -> T.Value Schema -> Either String (T.Value Schema)
+deconflictReaderUnion go valueSchema unionTypes val =
     let hdl [] = Left "Impossible: empty non-empty list."
         hdl (d:rest) =
-              case deconflictValue valueSchema d val of
+              case go valueSchema d val of
                 Right v -> Right (T.Union unionTypes d v)
                 Left _  -> hdl rest
     in hdl (V.toList unionTypes)
 
-deconflictRecord :: Schema -> Schema -> T.Value Schema -> Either String (T.Value Schema)
-deconflictRecord writerSchema readerSchema (T.Record ty fldVals)  =
-  T.Record readerSchema . HashMap.fromList <$> mapM (deconflictFields fldVals (fields writerSchema)) (fields readerSchema)
+deconflictRecord :: Deconflicter -> Schema -> Schema -> T.Value Schema -> Either String (T.Value Schema)
+deconflictRecord go writerSchema readerSchema (T.Record ty fldVals)  =
+  T.Record readerSchema . HashMap.fromList <$> mapM (deconflictFields go fldVals (fields writerSchema)) (fields readerSchema)
 
 -- For each field of the decoders, lookup the field in the hash map
---  1) If the field exists, call 'deconflictValue'
+--  1) If the field exists, call the given deconflicting function
 --  2) If the field is missing use the reader's default
 --  3) If there is no default, fail.
 --
 -- XXX: Consider aliases in the writer schema, use those to retry on failed lookup.
-deconflictFields :: HashMap Text (T.Value Schema) -> [Field] -> Field -> Either String (Text,T.Value Schema)
-deconflictFields hm writerFields readerField =
+deconflictFields :: Deconflicter -> HashMap Text (T.Value Schema) -> [Field] -> Field -> Either String (Text, T.Value Schema)
+deconflictFields go hm writerFields readerField =
   let
     mbWriterField = findField readerField writerFields
     mbValue = HashMap.lookup (fldName readerField) hm
   in case (mbWriterField, mbValue, fldDefault readerField) of
-    (Just w, Just x,_)  -> (fldName readerField,) <$> deconflictValue (fldType w) (fldType readerField) x
+    (Just w, Just x,_)  -> (fldName readerField,) <$> go (fldType w) (fldType readerField) x
     (_, Just x,_)       -> Right (fldName readerField, x)
     (_, _,Just def)     -> Right (fldName readerField, def)
     (_,Nothing,Nothing) -> Left $ "No field and no default for " ++ show (fldName readerField)

--- a/src/Data/Avro/Deriving.hs
+++ b/src/Data/Avro/Deriving.hs
@@ -167,19 +167,19 @@ mkStrictPrimitiveField _ field =
   where
     unpackedness =
       case S.fldType field of
-        S.Null    -> NonUnpackedField
-        S.Boolean -> NonUnpackedField
-        _         -> UnpackedField
+        S.Null _    -> NonUnpackedField
+        S.Boolean _ -> NonUnpackedField
+        _           -> UnpackedField
 
     shouldStricten =
       case S.fldType field of
-        S.Null    -> True
-        S.Boolean -> True
-        S.Int     -> True
-        S.Long    -> True
-        S.Float   -> True
-        S.Double  -> True
-        _         -> False
+        S.Null _    -> True
+        S.Boolean _ -> True
+        S.Int _     -> True
+        S.Long _    -> True
+        S.Float _   -> True
+        S.Double _  -> True
+        _           -> False
 
 -- | Generates a field name that matches the field name in schema
 -- (sanitised for Haskell, so first letter is lower cased)
@@ -490,11 +490,11 @@ genType _ _ = pure []
 
 mkFieldTypeName :: NamespaceBehavior -> S.Schema -> Q TH.Type
 mkFieldTypeName namespaceBehavior = \case
-  S.Boolean          -> [t| Bool |]
-  S.Long             -> [t| Int64 |]
-  S.Int              -> [t| Int32 |]
-  S.Float            -> [t| Float |]
-  S.Double           -> [t| Double |]
+  S.Boolean _        -> [t| Bool |]
+  S.Long _           -> [t| Int64 |]
+  S.Int _            -> [t| Int32 |]
+  S.Float _          -> [t| Float |]
+  S.Double _         -> [t| Double |]
   S.Bytes            -> [t| ByteString |]
   S.String           -> [t| Text |]
   S.Union branches   -> union (V.toList branches)
@@ -507,8 +507,8 @@ mkFieldTypeName namespaceBehavior = \case
   t                  -> error $ "Avro type is not supported: " <> show t
   where go = mkFieldTypeName namespaceBehavior
         union = \case
-          [Null, x]       -> [t| Maybe $(go x) |]
-          [x, Null]       -> [t| Maybe $(go x) |]
+          [Null _, x]     -> [t| Maybe $(go x) |]
+          [x, Null _]     -> [t| Maybe $(go x) |]
           [x, y]          -> [t| Either $(go x) $(go y) |]
           [a, b, c]       -> [t| Either3 $(go a) $(go b) $(go c) |]
           [a, b, c, d]    -> [t| Either4 $(go a) $(go b) $(go c) $(go d) |]

--- a/src/Data/Avro/Deriving/Lift.hs
+++ b/src/Data/Avro/Deriving/Lift.hs
@@ -2,6 +2,8 @@
 {-# LANGUAGE DeriveLift         #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell    #-}
+{-# LANGUAGE GADTs              #-}
+
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
@@ -36,3 +38,14 @@ deriving instance Lift Schema.Order
 deriving instance Lift Schema.TypeName
 deriving instance Lift Schema.Schema
 deriving instance Lift Schema.FieldStatus
+deriving instance Lift (Schema.ReadRule a)
+
+-- instance Lift (Schema.ReadRule a) where
+--   lift Schema.ReadAsIs = [| Schema.ReadAsIs |]
+--   lift Schema.ReadIgnore = [| Schema.ReadIgnore |]
+--   lift Schema.ReadLongFromInt = [| Schema.ReadLongFromInt |]     
+--   lift Schema.ReadFloatFromInt = [| Schema.ReadFloatFromInt |]   
+--   lift Schema.ReadDoubleFromInt = [| Schema.ReadDoubleFromInt |]   
+--   lift Schema.ReadFloatFromLong = [| Schema.ReadFloatFromLong |]   
+--   lift Schema.ReadDoubleFromLong = [| Schema.ReadDoubleFromLong |]  
+--   lift Schema.ReadDoubleFromFloat = [| Schema.ReadDoubleFromFloat |] 

--- a/src/Data/Avro/Deriving/Lift.hs
+++ b/src/Data/Avro/Deriving/Lift.hs
@@ -35,3 +35,4 @@ deriving instance Lift Schema.Field
 deriving instance Lift Schema.Order
 deriving instance Lift Schema.TypeName
 deriving instance Lift Schema.Schema
+deriving instance Lift Schema.FieldStatus

--- a/src/Data/Avro/Encode.hs
+++ b/src/Data/Avro/Encode.hs
@@ -176,10 +176,10 @@ class EncodeAvro a where
   avro :: a -> AvroM
 
 avroInt :: forall a. (FiniteBits a, Integral a, EncodeRaw a) => a -> AvroM
-avroInt n = AvroM (encodeRaw n, S.Int)
+avroInt n = AvroM (encodeRaw n, S.Int ReadAsIs)
 
 avroLong :: forall a. (FiniteBits a, Integral a, EncodeRaw a) => a -> AvroM
-avroLong n = AvroM (encodeRaw n, S.Long)
+avroLong n = AvroM (encodeRaw n, S.Long ReadAsIs)
 
 -- Put a Haskell Int.
 putI :: Int -> Builder
@@ -222,10 +222,10 @@ instance EncodeAvro String where
   avro s = let t = T.pack s in avro t
 
 instance EncodeAvro Double where
-  avro d = AvroM (word64LE (IEEE.doubleToWord d), S.Double)
+  avro d = AvroM (word64LE (IEEE.doubleToWord d), S.Double ReadAsIs)
 
 instance EncodeAvro Float where
-  avro d = AvroM (word32LE (IEEE.floatToWord d), S.Float)
+  avro d = AvroM (word32LE (IEEE.floatToWord d), S.Float ReadAsIs)
 
 -- Terminating word for array and map types.
 long0 :: Builder
@@ -265,14 +265,14 @@ instance EncodeAvro a => EncodeAvro (HashMap Text a) where
 
 -- | Maybe is modeled as a sum type `{null, a}`.
 instance EncodeAvro a => EncodeAvro (Maybe a) where
-  avro Nothing  = AvroM (putI 0             , S.mkUnion (S.Null:|[S.Int]))
-  avro (Just x) = AvroM (putI 1 <> putAvro x, S.mkUnion (S.Null:|[S.Int]))
+  avro Nothing  = AvroM (putI 0             , S.mkUnion (S.Null ReadAsIs :|[S.Int ReadAsIs]))
+  avro (Just x) = AvroM (putI 1 <> putAvro x, S.mkUnion (S.Null ReadAsIs :|[S.Int ReadAsIs]))
 
 instance EncodeAvro () where
-  avro () = AvroM (mempty, S.Null)
+  avro () = AvroM (mempty, S.Null ReadAsIs)
 
 instance EncodeAvro Bool where
-  avro b = AvroM (word8 $ fromIntegral $ fromEnum b, S.Boolean)
+  avro b = AvroM (word8 $ fromIntegral $ fromEnum b, S.Boolean ReadAsIs)
 
 --------------------------------------------------------------------------------
 --  Common Intermediate Representation Encoding

--- a/src/Data/Avro/FromAvro.hs
+++ b/src/Data/Avro/FromAvro.hs
@@ -85,8 +85,8 @@ instance FromAvro Float where
 
 instance FromAvro a => FromAvro (Maybe a) where
   fromAvro (T.Union ts _ v) = case (V.toList ts, v) of
-    ([S.Null, _], T.Null) -> pure Nothing
-    ([S.Null, _], v')     -> Just <$> fromAvro v'
+    ([S.Null _, _], T.Null) -> pure Nothing
+    ([S.Null _, _], v')     -> Just <$> fromAvro v'
     _                     -> badValue v "Maybe a"
   fromAvro v                = badValue v "Maybe a"
 

--- a/src/Data/Avro/HasAvroSchema.hs
+++ b/src/Data/Avro/HasAvroSchema.hs
@@ -33,43 +33,43 @@ schemaOf :: (HasAvroSchema a) => a -> Schema
 schemaOf = witness schema
 
 instance HasAvroSchema Word8 where
-  schema = Tagged S.Int
+  schema = Tagged (S.Int ReadAsIs)
 
 instance HasAvroSchema Word16 where
-  schema = Tagged S.Int
+  schema = Tagged (S.Int ReadAsIs)
 
 instance HasAvroSchema Word32 where
-  schema = Tagged S.Long
+  schema = Tagged (S.Long ReadAsIs)
 
 instance HasAvroSchema Word64 where
-  schema = Tagged S.Long
+  schema = Tagged (S.Long ReadAsIs)
 
 instance HasAvroSchema Bool where
-  schema = Tagged S.Boolean
+  schema = Tagged (S.Boolean ReadAsIs)
 
 instance HasAvroSchema () where
-  schema = Tagged S.Null
+  schema = Tagged (S.Null ReadAsIs)
 
 instance HasAvroSchema Int where
-  schema = Tagged S.Long
+  schema = Tagged (S.Long ReadAsIs)
 
 instance HasAvroSchema Int8 where
-  schema = Tagged S.Int
+  schema = Tagged (S.Int ReadAsIs)
 
 instance HasAvroSchema Int16 where
-  schema = Tagged S.Int
+  schema = Tagged (S.Int ReadAsIs)
 
 instance HasAvroSchema Int32 where
-  schema = Tagged S.Int
+  schema = Tagged (S.Int ReadAsIs)
 
 instance HasAvroSchema Int64 where
-  schema = Tagged S.Long
+  schema = Tagged (S.Long ReadAsIs)
 
 instance HasAvroSchema Double where
-  schema = Tagged S.Double
+  schema = Tagged (S.Double ReadAsIs)
 
 instance HasAvroSchema Float where
-  schema = Tagged S.Float
+  schema = Tagged (S.Float ReadAsIs)
 
 instance HasAvroSchema Text.Text where
   schema = Tagged S.String
@@ -105,7 +105,7 @@ instance (HasAvroSchema a) => HasAvroSchema (HashMap.HashMap String a) where
   schema = wrapTag S.Map (schema :: Tagged a Schema)
 
 instance (HasAvroSchema a) => HasAvroSchema (Maybe a) where
-  schema = Tagged $ mkUnion (S.Null:| [untag (schema :: Tagged a Schema)])
+  schema = Tagged $ mkUnion (S.Null ReadAsIs :| [untag (schema :: Tagged a Schema)])
 
 instance (HasAvroSchema a) => HasAvroSchema [a] where
   schema = wrapTag S.Array (schema :: Tagged a Schema)

--- a/src/Data/Avro/JSON.hs
+++ b/src/Data/Avro/JSON.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE GADTs               #-}
 -- | Avro supports a JSON representation of Avro objects alongside the
 -- Avro binary format. An Avro schema can be used to generate and
 -- validate JSON representations of Avro objects.
@@ -87,8 +88,8 @@ decodeAvroJSON schema json =
       fail ("Type " <> show name <> " not in schema")
 
     union (Schema.Union schemas) Aeson.Null
-      | Schema.Null `elem` schemas =
-          pure $ Avro.Union schemas Schema.Null Avro.Null
+      | Schema.Null Schema.ReadAsIs `elem` schemas =
+          pure $ Avro.Union schemas (Schema.Null Schema.ReadAsIs) Avro.Null
       | otherwise                  =
           fail "Null not in union."
     union (Schema.Union schemas) (Aeson.Object obj)

--- a/src/Data/Avro/Schema.hs
+++ b/src/Data/Avro/Schema.hs
@@ -605,6 +605,8 @@ parseAvroJSON union env ty av                  =
             when (len /= size) $
               fail $ "Fixed string wrong size. Expected " <> show size <> " but got " <> show len
             return $ Ty.Fixed ty bytes
+          _ -> fail $ "Expected type String, Enum, Bytes, or Fixed, but found (Type,Value)="
+             <> show (ty, av)
       A.Bool b       -> case ty of
                           Boolean -> return $ Ty.Boolean b
                           _       -> avroTypeMismatch ty "boolean"

--- a/src/Data/Avro/Schema/Deconflict.hs
+++ b/src/Data/Avro/Schema/Deconflict.hs
@@ -1,0 +1,170 @@
+{-# LANGUAGE TupleSections #-}
+module Data.Avro.Schema.Deconflict
+  ( deconflict
+  ) where
+
+import           Control.Applicative ((<|>))
+import           Data.Avro.Schema    as S
+import           Data.Avro.Types     as T
+import qualified Data.Foldable       as Foldable
+import           Data.HashMap.Strict (HashMap)
+import qualified Data.HashMap.Strict as HashMap
+import           Data.List           (find)
+import           Data.List.NonEmpty  (NonEmpty (..))
+import qualified Data.List.NonEmpty  as NE
+import qualified Data.Map            as M
+import           Data.Semigroup      ((<>))
+import qualified Data.Set            as Set
+import           Data.Text           (Text)
+import qualified Data.Text           as Text
+import qualified Data.Text.Encoding  as Text
+import           Data.Traversable    (forM)
+import           Data.Vector         (Vector)
+import qualified Data.Vector         as V
+
+-- | @deconflict writer reader@ will produce a schema that can encode/decode
+-- with the writer's schema into the form specified by the reader's schema.
+-- The returned schema is lazy in that it may have errors (but those will not
+-- get in the way of pure parsing).
+deconflict :: Schema -- ^ Writer schema
+           -> Schema -- ^ Reader schema
+           -> Schema
+deconflict writerSchema readerSchema = go writerSchema readerSchema
+  where
+    go :: Schema -> Schema -> Schema
+    go aTy bTy
+      | aTy == bTy = aTy
+    go (S.Array aTy) (S.Array bTy) =
+      S.Array $ go aTy bTy
+    go (S.Map aTy) (S.Map bTy) =
+      S.Map $ go aTy bTy
+    go a@S.Enum{} b@S.Enum{}
+      | name a == name b && symbols b `contains` symbols a = S.Enum
+        { name    = name a
+        , aliases = aliases a <> aliases b
+        , doc     = doc a
+        , symbols = symbols a
+        }
+    go a@S.Fixed {} b@S.Fixed {}
+      | name a == name b && size a == size b = S.Fixed
+        { name    = name a
+        , aliases = aliases a <> aliases b
+        , size    = size a
+        }
+    go a@S.Record {} b@S.Record {}
+      | name a == name b && order b `moreSpecified` order a =
+        let fields' = deconflictFields (fields a) (fields b)
+        in S.Record
+          { name    = name a
+          , aliases = aliases a <> aliases b
+          , doc     = doc a
+          , order   = order b
+          , fields  = fields'
+          }
+    go (S.Union xs) (S.Union ys) =
+      let err x = S.Panic x $ "Incorrect payload: union " <> (show . Foldable.toList $ typeName <$> ys) <> " does not contain schema " <> Text.unpack (typeName x)
+      in S.Union $ (\x -> maybe (err x) (go x) (findType x ys)) <$> xs
+    go nonUnion (S.Union ys)
+      | Just y <- findType nonUnion ys =
+        S.FreeUnion (go nonUnion y)
+    go from S.Int | isIntIn from = S.Int
+    go from to | isIntIn   from && isLongOut   to = S.IntLongCoercion
+    go from to | isIntIn   from && isFloatOut  to = S.IntFloatCoercion
+    go from to | isIntIn   from && isDoubleOut to = S.IntDoubleCoercion
+    go from to | isLongIn  from && isLongOut   to = S.Long
+    go from to | isLongIn  from && isFloatOut  to = S.LongFloatCoercion
+    go from to | isLongIn  from && isDoubleOut to = S.LongDoubleCoercion
+    go from to | isFloatIn from && isFloatOut  to = S.Float
+    go from to | isFloatIn from && isDoubleOut to = S.FloatDoubleCoercion
+    go S.Double to | isDoubleOut to = S.Double
+    go S.Bytes  S.String = S.Bytes  -- These are free coercions
+    go S.String S.Bytes  = S.String -- These are free coercions
+    go (S.FreeUnion a) b = go a b -- Free unions are free to discard
+    go a (S.FreeUnion b) = go a b -- Free unions are free to discard
+    go a b = S.Panic a $ "Can not resolve differing writer and reader schemas: " ++ show (a, b)
+
+isIntIn :: Schema -> Bool
+isIntIn S.Int               = True
+isIntIn S.IntLongCoercion   = True
+isIntIn S.IntFloatCoercion  = True
+isIntIn S.IntDoubleCoercion = True
+isIntIn _                   = False
+
+isLongIn :: Schema -> Bool
+isLongIn S.Long               = True
+isLongIn S.LongFloatCoercion  = True
+isLongIn S.LongDoubleCoercion = True
+isLongIn _                    = False
+
+isFloatIn :: Schema -> Bool
+isFloatIn S.Float               = True
+isFloatIn S.FloatDoubleCoercion = True
+isFloatIn _                     = False
+
+isLongOut :: Schema -> Bool
+isLongOut S.Long            = True
+isLongOut S.IntLongCoercion = True
+isLongOut _                 = False
+
+isFloatOut :: Schema -> Bool
+isFloatOut S.Float             = True
+isFloatOut S.IntFloatCoercion  = True
+isFloatOut S.LongFloatCoercion = True
+isFloatOut _                   = False
+
+isDoubleOut :: Schema -> Bool
+isDoubleOut S.Double              = True
+isDoubleOut S.IntDoubleCoercion   = True
+isDoubleOut S.LongDoubleCoercion  = True
+isDoubleOut S.FloatDoubleCoercion = True
+isDoubleOut _                     = False
+
+moreSpecified :: Maybe Order -> Maybe Order -> Bool
+moreSpecified _ Nothing       = True
+moreSpecified _ (Just Ignore) = True
+moreSpecified (Just Ascending)  (Just Ascending)  = True
+moreSpecified (Just Descending) (Just Descending) = True
+moreSpecified _ _ = False
+
+contains :: V.Vector Text -> V.Vector Text -> Bool
+contains container elts =
+  and [e `V.elem` container | e <- V.toList elts]
+
+-- For each field:
+--  1) If it exists in both schemas, deconflict it
+--  2) If it's only in the reader schema and has a default, mark it defaulted.
+--  2) If it's only in the reader schema and has no default, set its type to Panic.
+--  3) If it's only in the writer schema, mark it ignored.
+deconflictFields :: [Field] -> [Field] -> [Field]
+deconflictFields writerFields readerFields =
+  (deconflictField <$> writerFields) <> defaultedFields
+  where
+    defaultedFields = [makeDefaulted f | f <- readerFields, findField f writerFields == Nothing]
+
+    makeDefaulted :: Field -> Field
+    makeDefaulted f
+      | Just def <- fldDefault f = f { fldStatus = Defaulted def }
+      | otherwise = f { fldType =
+        S.Panic (fldType f) ("No default found for deconflicted field "<>Text.unpack (fldName f)) }
+
+    deconflictField :: Field -> Field
+    deconflictField writerField
+      | Just readerField <- findField writerField readerFields =
+        writerField { fldType = deconflict (fldType writerField) (fldType readerField) }
+      | otherwise =
+        writerField { fldStatus = Ignored }
+
+findField :: Field -> [Field] -> Maybe Field
+findField f fs =
+  let
+    byName = find (\x -> fldName x == fldName f) fs
+    allNames fld = Set.fromList (fldName fld : fldAliases fld)
+    fNames = allNames f
+    sameField = not . Set.null . Set.intersection fNames . allNames
+    byAliases = find sameField fs
+  in byName <|> byAliases
+
+findType :: Foldable f => Schema -> f Schema -> Maybe Schema
+findType schema =
+  let tn = typeName schema
+  in Foldable.find ((tn ==) . typeName) -- TODO: Consider aliases

--- a/src/Data/Avro/ToAvro.hs
+++ b/src/Data/Avro/ToAvro.hs
@@ -92,7 +92,7 @@ instance (ToAvro a) => ToAvro (Maybe a) where
   toAvro a =
     let sch = options (schemaOf a)
     in case a of
-      Nothing -> T.Union sch S.Null (toAvro ())
+      Nothing -> T.Union sch (S.Null ReadAsIs) (toAvro ())
       Just v  -> T.Union sch (schemaOf v) (toAvro v)
 
 instance (ToAvro a) => ToAvro [a] where

--- a/test/Avro/Codec/BoolSpec.hs
+++ b/test/Avro/Codec/BoolSpec.hs
@@ -27,7 +27,7 @@ onlyBoolSchema :: Schema
 onlyBoolSchema =
   let fld nm = Field nm [] Nothing Nothing AsIs
    in Record "test.contract.OnlyBool" [] Nothing Nothing
-        [ fld "onlyBoolValue" Boolean Nothing
+        [ fld "onlyBoolValue" (Boolean ReadAsIs) Nothing
         ]
 
 instance HasAvroSchema OnlyBool where

--- a/test/Avro/Codec/BoolSpec.hs
+++ b/test/Avro/Codec/BoolSpec.hs
@@ -25,7 +25,7 @@ newtype OnlyBool = OnlyBool
 
 onlyBoolSchema :: Schema
 onlyBoolSchema =
-  let fld nm = Field nm [] Nothing Nothing
+  let fld nm = Field nm [] Nothing Nothing AsIs
    in Record "test.contract.OnlyBool" [] Nothing Nothing
         [ fld "onlyBoolValue" Boolean Nothing
         ]

--- a/test/Avro/Codec/DoubleSpec.hs
+++ b/test/Avro/Codec/DoubleSpec.hs
@@ -19,7 +19,7 @@ newtype OnlyDouble = OnlyDouble
 
 onlyDoubleSchema :: Schema
 onlyDoubleSchema =
-  let fld nm = Field nm [] Nothing Nothing
+  let fld nm = Field nm [] Nothing Nothing AsIs
   in Record "test.contract.OnlyDouble" [] Nothing Nothing
         [ fld "onlyDoubleValue" Double Nothing
         ]

--- a/test/Avro/Codec/DoubleSpec.hs
+++ b/test/Avro/Codec/DoubleSpec.hs
@@ -21,7 +21,7 @@ onlyDoubleSchema :: Schema
 onlyDoubleSchema =
   let fld nm = Field nm [] Nothing Nothing AsIs
   in Record "test.contract.OnlyDouble" [] Nothing Nothing
-        [ fld "onlyDoubleValue" Double Nothing
+        [ fld "onlyDoubleValue" (Double ReadAsIs) Nothing
         ]
 
 instance HasAvroSchema OnlyDouble where

--- a/test/Avro/Codec/FloatSpec.hs
+++ b/test/Avro/Codec/FloatSpec.hs
@@ -21,7 +21,7 @@ onlyFloatSchema :: Schema
 onlyFloatSchema =
   let fld nm = Field nm [] Nothing Nothing AsIs
   in Record "test.contract.OnlyFloat" [] Nothing Nothing
-        [ fld "onlyFloatValue" Float Nothing
+        [ fld "onlyFloatValue" (Float ReadAsIs) Nothing
         ]
 
 instance HasAvroSchema OnlyFloat where

--- a/test/Avro/Codec/FloatSpec.hs
+++ b/test/Avro/Codec/FloatSpec.hs
@@ -19,7 +19,7 @@ newtype OnlyFloat = OnlyFloat
 
 onlyFloatSchema :: Schema
 onlyFloatSchema =
-  let fld nm = Field nm [] Nothing Nothing
+  let fld nm = Field nm [] Nothing Nothing AsIs
   in Record "test.contract.OnlyFloat" [] Nothing Nothing
         [ fld "onlyFloatValue" Float Nothing
         ]

--- a/test/Avro/Codec/Int64Spec.hs
+++ b/test/Avro/Codec/Int64Spec.hs
@@ -34,7 +34,7 @@ onlyInt64Schema :: Schema
 onlyInt64Schema =
   let fld nm = Field nm [] Nothing Nothing AsIs
    in Record "test.contract.OnlyInt64" [] Nothing Nothing
-        [ fld "onlyInt64Value"    Long Nothing
+        [ fld "onlyInt64Value"    (Long ReadAsIs) Nothing
         ]
 
 instance HasAvroSchema OnlyInt64 where

--- a/test/Avro/Codec/Int64Spec.hs
+++ b/test/Avro/Codec/Int64Spec.hs
@@ -32,7 +32,7 @@ newtype OnlyInt64 = OnlyInt64
 
 onlyInt64Schema :: Schema
 onlyInt64Schema =
-  let fld nm = Field nm [] Nothing Nothing
+  let fld nm = Field nm [] Nothing Nothing AsIs
    in Record "test.contract.OnlyInt64" [] Nothing Nothing
         [ fld "onlyInt64Value"    Long Nothing
         ]

--- a/test/Avro/Codec/MaybeSpec.hs
+++ b/test/Avro/Codec/MaybeSpec.hs
@@ -22,7 +22,7 @@ newtype OnlyMaybeBool = OnlyMaybeBool
 
 onlyMaybeBoolSchema :: Schema
 onlyMaybeBoolSchema =
-  let fld nm = Field nm [] Nothing Nothing
+  let fld nm = Field nm [] Nothing Nothing AsIs
    in Record "test.contract.onlyMaybeBool" [] Nothing Nothing
         [ fld "onlyMaybeBoolValue" (mkUnion (Null :| [Boolean])) Nothing
         ]

--- a/test/Avro/Codec/MaybeSpec.hs
+++ b/test/Avro/Codec/MaybeSpec.hs
@@ -24,7 +24,7 @@ onlyMaybeBoolSchema :: Schema
 onlyMaybeBoolSchema =
   let fld nm = Field nm [] Nothing Nothing AsIs
    in Record "test.contract.onlyMaybeBool" [] Nothing Nothing
-        [ fld "onlyMaybeBoolValue" (mkUnion (Null :| [Boolean])) Nothing
+        [ fld "onlyMaybeBoolValue" (mkUnion (Null ReadAsIs :| [Boolean ReadAsIs])) Nothing
         ]
 
 instance HasAvroSchema OnlyMaybeBool where

--- a/test/Avro/Codec/NestedSpec.hs
+++ b/test/Avro/Codec/NestedSpec.hs
@@ -25,15 +25,15 @@ childTypeSchema :: Schema
 childTypeSchema =
   let fld nm = Field nm [] Nothing Nothing AsIs
   in Record "test.contract.ChildType" [] Nothing Nothing
-        [ fld "childValue1" Long Nothing
-        , fld "childValue2" Long Nothing
+        [ fld "childValue1" (Long ReadAsIs) Nothing
+        , fld "childValue2" (Long ReadAsIs) Nothing
         ]
 
 parentTypeSchema :: Schema
 parentTypeSchema =
   let fld nm = Field nm [] Nothing Nothing AsIs
   in Record "test.contract.ParentType" [] Nothing Nothing
-        [ fld "parentValue1" Long             Nothing
+        [ fld "parentValue1" (Long ReadAsIs)             Nothing
         , fld "parentValue2" (Array childTypeSchema)  Nothing]
 
 instance HasAvroSchema ParentType where

--- a/test/Avro/Codec/NestedSpec.hs
+++ b/test/Avro/Codec/NestedSpec.hs
@@ -23,7 +23,7 @@ data ParentType = ParentType
 
 childTypeSchema :: Schema
 childTypeSchema =
-  let fld nm = Field nm [] Nothing Nothing
+  let fld nm = Field nm [] Nothing Nothing AsIs
   in Record "test.contract.ChildType" [] Nothing Nothing
         [ fld "childValue1" Long Nothing
         , fld "childValue2" Long Nothing
@@ -31,7 +31,7 @@ childTypeSchema =
 
 parentTypeSchema :: Schema
 parentTypeSchema =
-  let fld nm = Field nm [] Nothing Nothing
+  let fld nm = Field nm [] Nothing Nothing AsIs
   in Record "test.contract.ParentType" [] Nothing Nothing
         [ fld "parentValue1" Long             Nothing
         , fld "parentValue2" (Array childTypeSchema)  Nothing]

--- a/test/Avro/Codec/TextSpec.hs
+++ b/test/Avro/Codec/TextSpec.hs
@@ -20,7 +20,7 @@ newtype OnlyText = OnlyText
 
 onlyTextSchema :: Schema
 onlyTextSchema =
-  let fld nm = Field nm [] Nothing Nothing
+  let fld nm = Field nm [] Nothing Nothing AsIs
   in Record "test.contract.OnlyText" [] Nothing Nothing
         [ fld "onlyTextValue" String Nothing
         ]

--- a/test/Avro/Deconflict/B/README.md
+++ b/test/Avro/Deconflict/B/README.md
@@ -1,1 +1,1 @@
-# Adding an nested optional field
+# Adding a nested optional field

--- a/test/Avro/Deconflict/C/README.md
+++ b/test/Avro/Deconflict/C/README.md
@@ -1,1 +1,1 @@
-# Removing an nested optional field
+# Removing a nested optional field

--- a/test/Avro/Deconflict/D/README.md
+++ b/test/Avro/Deconflict/D/README.md
@@ -1,0 +1,1 @@
+# Adding a recursive optional field

--- a/test/Avro/Deconflict/D/Reader.hs
+++ b/test/Avro/Deconflict/D/Reader.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes       #-}
+{-# LANGUAGE TemplateHaskell   #-}
+
+module Avro.Deconflict.D.Reader where
+
+import Data.Avro.Deriving
+import Text.RawString.QQ
+
+deriveAvroFromByteString [r|
+[
+{ "name": "Foo",
+  "type": "record",
+  "fields": [
+    { "name": "constructor",
+      "type": [
+        { "name": "Bar",
+          "type": "record",
+          "fields": [
+            { "name": "fieldA", "type": "int" },
+            { "name": "fieldB", "type": [ "null", "string" ], "default": null }
+          ]
+        },
+        { "name": "Baz",
+          "type": "record",
+          "fields": [
+            { "name": "fieldC", "type": "Foo" }
+          ]
+        }
+      ]
+    }
+  ]
+}
+]
+|]
+
+sampleValue :: Foo
+sampleValue =
+  Foo (Right (Baz (Foo (Right (Baz (Foo (Left $ Bar 12 Nothing)))))))

--- a/test/Avro/Deconflict/D/Writer.hs
+++ b/test/Avro/Deconflict/D/Writer.hs
@@ -1,0 +1,39 @@
+{-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes       #-}
+{-# LANGUAGE TemplateHaskell   #-}
+
+module Avro.Deconflict.D.Writer where
+
+import Data.Avro.Deriving
+import Text.RawString.QQ
+
+deriveAvroFromByteString [r|
+[
+{ "name": "Foo",
+  "type": "record",
+  "fields": [
+    { "name": "constructor",
+      "type": [
+        { "name": "Bar",
+          "type": "record",
+          "fields": [
+            { "name": "fieldA", "type": "int" }
+          ]
+        },
+        { "name": "Baz",
+          "type": "record",
+          "fields": [
+            { "name": "fieldC", "type": "Foo" }
+          ]
+        }
+      ]
+    }
+  ]
+}
+]
+|]
+
+sampleValue :: Foo
+sampleValue =
+  Foo (Right (Baz (Foo (Right (Baz (Foo (Left $ Bar 12)))))))

--- a/test/Avro/DeconflictSpec.hs
+++ b/test/Avro/DeconflictSpec.hs
@@ -20,9 +20,9 @@ import qualified Avro.Deconflict.D.Reader         as DR
 import qualified Avro.Deconflict.D.Writer         as DW
 import qualified Data.Avro.Decode                 as A (decodeAvro)
 import qualified Data.Avro.Decode.Lazy            as AL
-import qualified Data.Avro.Decode.Lazy.Deconflict as AL
-import qualified Data.Avro.Deconflict             as A
 import qualified Data.Avro.Types                  as Ty
+
+import qualified Data.Avro.Schema.Deconflict as Dec
 
 import Test.Hspec
 
@@ -33,14 +33,14 @@ spec = describe "Avro.DeconflictSpec" $ do
   describe "Type A" $ do
     it "should deconflict simple message" $ do
       let payload = A.encode $ AW.Inner 3
-      let Right decodedAvro = A.decodeAvro AW.schema'Inner payload
-      let Right deconflicted = deconflict AW.schema'Inner AR.schema'Inner decodedAvro
+      let deconflictedSchema = Dec.deconflict AW.schema'Inner AR.schema'Inner
+      let Right deconflicted = A.decodeAvro deconflictedSchema payload
       fromAvro deconflicted `shouldBe` Success (AR.Inner 3 Nothing)
 
-    it "should deconflict nested message" $ do
+    it "should deconflict strict message" $ do
       let payload = A.encode AW.sampleValue
-      let Right decodedAvro = A.decodeAvro AW.schema'Outer payload
-      let Right deconflicted = deconflict AW.schema'Outer AR.schema'Outer decodedAvro
+      let deconflictedSchema = Dec.deconflict AW.schema'Outer AR.schema'Outer
+      let Right deconflicted = A.decodeAvro deconflictedSchema payload
 
       fromAvro deconflicted `shouldBe` Success AR.sampleValue
 
@@ -54,35 +54,21 @@ spec = describe "Avro.DeconflictSpec" $ do
 
     it "should deconflict lazy value" $ do
       let payload = A.encode AW.sampleValue
-      let decodedAvro = AL.decodeAvro AW.schema'Outer payload
-      let deconflicted = AL.deconflict AW.schema'Outer AR.schema'Outer decodedAvro
+      let deconflictedSchema = Dec.deconflict AW.schema'Outer AR.schema'Outer
+      let deconflicted = AL.decodeAvro deconflictedSchema payload
 
       AL.fromLazyAvro deconflicted `shouldBe` Success AR.sampleValue
 
-    it "should deconflict strict value" $ do
-      let payload = A.encode AW.sampleValue
-      let Right decodedAvro = A.decodeAvro AW.schema'Outer payload
-      let Right deconflicted = A.deconflict AW.schema'Outer AR.schema'Outer decodedAvro
-
-      A.fromAvro deconflicted `shouldBe` Success AR.sampleValue
-
 
   describe "Type B" $ do
-    it "should deconflict complex type" $ do
-      let payload = A.encode BW.sampleValue
-      let decodedAvro = AL.decodeAvro BW.schema'Foo payload
-      let res = AL.deconflict BW.schema'Foo BR.schema'Foo decodedAvro
-
-      AL.fromLazyAvro res `shouldBe` Success BR.sampleValue
-
     it "should deconflict lazy container" $ do
       w <- liftIO $ A.encodeContainer [[ BW.sampleValue ]]
       AL.decodeContainer w `shouldBe` [ Right BR.sampleValue ]
 
     it "should deconflict lazy value" $ do
       let payload = A.encode BW.sampleValue
-      let decodedAvro = AL.decodeAvro BW.schema'Foo payload
-      let deconflicted = AL.deconflict BW.schema'Foo BR.schema'Foo decodedAvro
+      let deconflictedSchema = Dec.deconflict BW.schema'Foo BR.schema'Foo
+      let deconflicted = AL.decodeAvro deconflictedSchema payload
 
       AL.fromLazyAvro deconflicted `shouldBe` Success BR.sampleValue
 
@@ -92,27 +78,20 @@ spec = describe "Avro.DeconflictSpec" $ do
 
     it "should deconflict strict value" $ do
       let payload = A.encode BW.sampleValue
-      let Right decodedAvro = A.decodeAvro BW.schema'Foo payload
-      let Right deconflicted = A.deconflict BW.schema'Foo BR.schema'Foo decodedAvro
+      let deconflictedSchema = Dec.deconflict BW.schema'Foo BR.schema'Foo
+      let Right deconflicted = A.decodeAvro deconflictedSchema payload
 
       A.fromAvro deconflicted `shouldBe` Success BR.sampleValue
 
   describe "Type C" $ do
-    it "should deconflict complex type" $ do
-      let payload = A.encode CW.sampleValue
-      let decodedAvro = AL.decodeAvro CW.schema'Foo payload
-      let res = AL.deconflict CW.schema'Foo CR.schema'Foo decodedAvro
-
-      AL.fromLazyAvro res `shouldBe` Success CR.sampleValue
-
     it "should deconflict lazy container" $ do
       w <- liftIO $ A.encodeContainer [[ CW.sampleValue ]]
       AL.decodeContainer w `shouldBe` [ Right CR.sampleValue ]
 
     it "should deconflict lazy value" $ do
       let payload = A.encode CW.sampleValue
-      let decodedAvro = AL.decodeAvro CW.schema'Foo payload
-      let deconflicted = AL.deconflict CW.schema'Foo CR.schema'Foo decodedAvro
+      let deconflictedSchema = Dec.deconflict CW.schema'Foo CR.schema'Foo
+      let deconflicted = AL.decodeAvro deconflictedSchema payload
 
       AL.fromLazyAvro deconflicted `shouldBe` Success CR.sampleValue
 
@@ -122,27 +101,20 @@ spec = describe "Avro.DeconflictSpec" $ do
 
     it "should deconflict strict value" $ do
       let payload = A.encode CW.sampleValue
-      let Right decodedAvro = A.decodeAvro CW.schema'Foo payload
-      let Right deconflicted = A.deconflict CW.schema'Foo CR.schema'Foo decodedAvro
+      let deconflictedSchema = Dec.deconflict CW.schema'Foo CR.schema'Foo
+      let Right deconflicted = A.decodeAvro deconflictedSchema payload
 
       A.fromAvro deconflicted `shouldBe` Success CR.sampleValue
 
   describe "Type D" $ do
-    it "should deconflict complex type" $ do
-      let payload = A.encode DW.sampleValue
-      let decodedAvro = AL.decodeAvro DW.schema'Foo payload
-      let res = AL.deconflict DW.schema'Foo DR.schema'Foo decodedAvro
-
-      AL.fromLazyAvro res `shouldBe` Success DR.sampleValue
-
     it "should deconflict lazy container" $ do
       w <- liftIO $ A.encodeContainer [[ DW.sampleValue ]]
       AL.decodeContainer w `shouldBe` [ Right DR.sampleValue ]
 
     it "should deconflict lazy value" $ do
       let payload = A.encode DW.sampleValue
-      let decodedAvro = AL.decodeAvro DW.schema'Foo payload
-      let deconflicted = AL.deconflict DW.schema'Foo DR.schema'Foo decodedAvro
+      let deconflictedSchema = Dec.deconflict DW.schema'Foo DR.schema'Foo
+      let deconflicted = AL.decodeAvro deconflictedSchema payload
 
       AL.fromLazyAvro deconflicted `shouldBe` Success DR.sampleValue
 
@@ -152,7 +124,7 @@ spec = describe "Avro.DeconflictSpec" $ do
 
     it "should deconflict strict value" $ do
       let payload = A.encode DW.sampleValue
-      let Right decodedAvro = A.decodeAvro DW.schema'Foo payload
-      let Right deconflicted = A.deconflict DW.schema'Foo DR.schema'Foo decodedAvro
+      let deconflictedSchema = Dec.deconflict DW.schema'Foo DR.schema'Foo
+      let Right deconflicted = A.decodeAvro deconflictedSchema payload
 
       A.fromAvro deconflicted `shouldBe` Success DR.sampleValue

--- a/test/Avro/DefaultsSpec.hs
+++ b/test/Avro/DefaultsSpec.hs
@@ -35,7 +35,7 @@ spec = describe "Avro.DefaultsSpec: Schema with named types" $ do
       msgSchema = schemaOf (undefined :: MaybeTest)
       fixedSchema = schemaOf (undefined :: FixedTag)
       defaults = fldDefault <$> fields msgSchema
-    in defaults `shouldBe` [ Just $ Ty.Union (V.fromList [Null, String]) Null Ty.Null
+    in defaults `shouldBe` [ Just $ Ty.Union (V.fromList [Null ReadAsIs, String]) (Null ReadAsIs) Ty.Null
                            , Just $ Ty.Fixed fixedSchema "\0\42\255"
                            , Just $ Ty.Bytes "\0\37\255"
                            ]

--- a/test/Avro/NamespaceSpec.hs
+++ b/test/Avro/NamespaceSpec.hs
@@ -42,7 +42,7 @@ expected = Record
   , order   = Just Ascending
   , fields  = [field "bar" bar, field "baz" $ NamedType "com.example.baz.Baz"]
   }
-  where field name schema = Field name [] Nothing (Just Ascending) schema Nothing
+  where field name schema = Field name [] Nothing (Just Ascending) AsIs schema Nothing
 
         bar = Record
           { name    = "com.example.Bar"
@@ -73,7 +73,7 @@ expectedNullNamespace = Record
   , order   = Just Ascending
   , fields  = [field "bar" $ NamedType "Bar", field "baz" $ NamedType "com.example.Baz"]
   }
-  where field name schema = Field name [] Nothing (Just Ascending) schema Nothing
+  where field name schema = Field name [] Nothing (Just Ascending) AsIs schema Nothing
 
 
 getFileName :: FilePath -> IO FilePath

--- a/test/Avro/NormSchemaSpec.hs
+++ b/test/Avro/NormSchemaSpec.hs
@@ -7,7 +7,7 @@ where
 
 import           Data.Avro
 import           Data.Avro.Deriving
-import           Data.Avro.Schema   (Schema (..), fields, fldType, mkUnion)
+import           Data.Avro.Schema   (Schema (..), fields, fldType, mkUnion, ReadRule(..))
 import           Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.Set           as S
 
@@ -25,4 +25,4 @@ spec = describe "Avro.NormSchemaSpec" $ do
     (fldType <$> fields schema'ContainerChild) `shouldBe` [schema'ReusedChild, NamedType "Boo.ReusedChild"]
 
   it "should normalise schemas from unions" $
-     fldType <$> fields schema'Curse `shouldBe` [mkUnion (Null :| [schema'Geo])]
+     fldType <$> fields schema'Curse `shouldBe` [mkUnion (Null ReadAsIs :| [schema'Geo])]

--- a/test/Avro/THUnionSpec.hs
+++ b/test/Avro/THUnionSpec.hs
@@ -58,18 +58,18 @@ spec = describe "Avro.THUnionSpec: Schema with unions." $ do
       foo    = named "haskell.avro.example.Foo"
       notFoo = named "haskell.avro.example.NotFoo"
       expectedSchema = record "haskell.avro.example.Unions"
-        [ field "scalars"     (Schema.mkUnion (NE.fromList [Schema.String, Schema.Long])) scalarsDefault
-        , field "nullable"    (Schema.mkUnion (NE.fromList [Schema.Null, Schema.Int]))    nullableDefault
+        [ field "scalars"     (Schema.mkUnion (NE.fromList [Schema.String, Schema.Long Schema.ReadAsIs])) scalarsDefault
+        , field "nullable"    (Schema.mkUnion (NE.fromList [Schema.Null Schema.ReadAsIs, Schema.Int Schema.ReadAsIs]))    nullableDefault
         , field "records"     (Schema.mkUnion (NE.fromList [fooSchema, barSchema]))       Nothing
         , field "sameFields"  (Schema.mkUnion (NE.fromList [foo, notFooSchema]))          Nothing
         , field "arrayAndMap" (Schema.mkUnion (NE.fromList [array, map]))                 Nothing
 
-        , field "three" (Schema.mkUnion (NE.fromList [Schema.Int, Schema.String, Schema.Long]))              Nothing
-        , field "four"  (Schema.mkUnion (NE.fromList [Schema.Int, Schema.String, Schema.Long, foo]))         Nothing
-        , field "five"  (Schema.mkUnion (NE.fromList [Schema.Int, Schema.String, Schema.Long, foo, notFoo])) Nothing
+        , field "three" (Schema.mkUnion (NE.fromList [Schema.Int Schema.ReadAsIs, Schema.String, Schema.Long Schema.ReadAsIs]))              Nothing
+        , field "four"  (Schema.mkUnion (NE.fromList [Schema.Int Schema.ReadAsIs, Schema.String, Schema.Long Schema.ReadAsIs, foo]))         Nothing
+        , field "five"  (Schema.mkUnion (NE.fromList [Schema.Int Schema.ReadAsIs, Schema.String, Schema.Long Schema.ReadAsIs, foo, notFoo])) Nothing
         ]
-      scalarsDefault  = Just $ Avro.Union (V.fromList [Schema.String, Schema.Long]) Schema.String (Avro.String "foo")
-      nullableDefault = Just $ Avro.Union (V.fromList [Schema.Null, Schema.Int])    Schema.Null   Avro.Null
+      scalarsDefault  = Just $ Avro.Union (V.fromList [Schema.String, Schema.Long Schema.ReadAsIs]) Schema.String (Avro.String "foo")
+      nullableDefault = Just $ Avro.Union (V.fromList [Schema.Null Schema.ReadAsIs, Schema.Int Schema.ReadAsIs])    (Schema.Null Schema.ReadAsIs)   Avro.Null
 
       fooSchema = record "haskell.avro.example.Foo" [field "stuff" Schema.String Nothing]
       barSchema = record "haskell.avro.example.Bar"
@@ -79,7 +79,7 @@ spec = describe "Avro.THUnionSpec: Schema with unions." $ do
       notFooSchema = record "haskell.avro.example.NotFoo" [field "stuff" Schema.String Nothing]
 
       array = Schema.Array { Schema.item = Schema.String }
-      map   = Schema.Map { Schema.values = Schema.Long }
+      map   = Schema.Map { Schema.values = Schema.Long Schema.ReadAsIs }
 
   unionsSchemaFile <- runIO $ getFileName "test/data/unions.avsc" >>= LBS.readFile
   let Just unionsSchemaFromJSON = Aeson.decode unionsSchemaFile

--- a/test/Avro/THUnionSpec.hs
+++ b/test/Avro/THUnionSpec.hs
@@ -50,7 +50,7 @@ spec = describe "Avro.THUnionSpec: Schema with unions." $ do
         , unionsFive        = E5_5 $ NotFoo { notFooStuff = "not foo stuff" }
         }
 
-      field name schema def = Schema.Field name [] Nothing (Just Schema.Ascending) schema def
+      field name schema def = Schema.Field name [] Nothing (Just Schema.Ascending) Schema.AsIs schema def
       record name fields =
         Schema.Record name [] Nothing (Just Schema.Ascending) fields
       named = Schema.NamedType

--- a/test/Avro/ToAvroSpec.hs
+++ b/test/Avro/ToAvroSpec.hs
@@ -31,7 +31,7 @@ data TypesTestMessage = TypesTestMessage
 
 tmSchema :: Schema
 tmSchema =
-  let fld nm = Field nm [] Nothing Nothing
+  let fld nm = Field nm [] Nothing Nothing AsIs
    in Record "avro.haskell.test.TypesTestMessage" [] Nothing Nothing
         [ fld "id" Long Nothing
         , fld "name" String Nothing

--- a/test/Avro/ToAvroSpec.hs
+++ b/test/Avro/ToAvroSpec.hs
@@ -33,14 +33,14 @@ tmSchema :: Schema
 tmSchema =
   let fld nm = Field nm [] Nothing Nothing AsIs
    in Record "avro.haskell.test.TypesTestMessage" [] Nothing Nothing
-        [ fld "id" Long Nothing
+        [ fld "id" (Long ReadAsIs) Nothing
         , fld "name" String Nothing
-        , fld "timestamp" (mkUnion (Null :| [Long])) Nothing
-        , fld "foreignId" (mkUnion (Null :| [Long])) Nothing
-        , fld "competence" (mkUnion (Null :| [Double])) Nothing
-        , fld "relevance" (mkUnion (Null :| [Float])) Nothing
-        , fld "severity" Float Nothing
-        , fld "attraction" Double Nothing
+        , fld "timestamp" (mkUnion (Null ReadAsIs :| [Long ReadAsIs])) Nothing
+        , fld "foreignId" (mkUnion (Null ReadAsIs :| [Long ReadAsIs])) Nothing
+        , fld "competence" (mkUnion (Null ReadAsIs :| [Double ReadAsIs])) Nothing
+        , fld "relevance" (mkUnion (Null ReadAsIs :| [Float ReadAsIs])) Nothing
+        , fld "severity" (Float ReadAsIs) Nothing
+        , fld "attraction" (Double ReadAsIs) Nothing
         ]
 
 instance HasAvroSchema TypesTestMessage where

--- a/test/Example1.hs
+++ b/test/Example1.hs
@@ -23,7 +23,7 @@ msSchema  :: Schema
 msSchema =
   Record "MyStruct" [] Nothing Nothing
       [ fld "enumOrString" eOrS (Just $ Ty.String "The Default")
-      , fld "intvalue" Long Nothing
+      , fld "intvalue" (Long ReadAsIs) Nothing
       ]
      where
      fld nm ty def = Field nm [] Nothing Nothing AsIs ty def

--- a/test/Example1.hs
+++ b/test/Example1.hs
@@ -26,7 +26,7 @@ msSchema =
       , fld "intvalue" Long Nothing
       ]
      where
-     fld nm ty def = Field nm [] Nothing Nothing ty def
+     fld nm ty def = Field nm [] Nothing Nothing AsIs ty def
      eOrS = mkUnion (meSchema :| [String])
 
 -- Encoding data, via the ToAvro class, requires both the routine that encodes


### PR DESCRIPTION
## Changes

I am trying to use annotations instead of new constructors.
Here is an unfinished work with some pros and cons that I have found using this approach.

#### Pros
- Looks like it'd be possible to annotate schemas with `ReadIgnore a` which allows us not to touch `Field`. 
- Annotations can be quite type safe (thanks to GADTs)
- It is possible to manually create a schema that would use types conversion if needed (does anyone need it? does anyone create schemas manually)?
- Because annotations can be saved in JSON, it is possible to define `.avsc` containing these annotations (is it a useful feature anyway?)

#### Cons
- These bloody annotations are leaking everywhere! 
- The annotations are purely for reading, but just because they are there, the writer/encoder code must deal with them too!
- Requires special treatment in JSON encoding/decoding
- Manually defined schemas get slightly complicated because we should always add `ReadAsIs` annotation.

### Annotation vs. extra constructors
Annotations share some cons with extra constructors: avro writer/encoder should deal with with them, they  need to be taken into account when encoding schemas to/from JSON, etc.

Annotations' advantage is that they allow one Avro type to have only one constructor and not all possible permutations. 

Annotations' disadvantage is that they complicate Schema when it is defined manually.

Extra constructors' disadvantage is that `Ignore` cannot be moved to a Schema level, so both `Schema` and `Field` need to be updated.

## Todo

This work is largely unfinished. To complete it we need at least:

- Annotate all the schemas so that it would be possible to use `ReadIgnore`
- Use `ReadIgnore` annotation instead of `Field`
- Implement JSON serialisation for Schema (read/write annotations as attributes)
- Make use of this new schema in decoding
- Get rid of "old" deconflicting