### PR TITLE
Add deriving for unions with a single constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This library provides the following conversions between Haskell types and Avro t
 | ByteString        | "bytes"                         |
 | Maybe a           | ["null", "a"]                   |
 | Either a b        | ["a", "b"]                      |
+| Identity a        | ["a"]                           |
 | Map Text a        | {"type": "map", "value": "a"}   |
 | Map String a      | {"type": "map", "value": "a"}   |
 | HashMap Text a    | {"type": "map", "value": "a"}   |

--- a/src/Data/Avro/HasAvroSchema.hs
+++ b/src/Data/Avro/HasAvroSchema.hs
@@ -3,21 +3,22 @@
 {-# LANGUAGE ScopedTypeVariables  #-}
 module Data.Avro.HasAvroSchema where
 
-import qualified Data.Array           as Ar
-import           Data.Avro.Schema     as S
-import           Data.Avro.Types      as T
+import           Control.Monad.Identity  (Identity)
+import qualified Data.Array              as Ar
+import           Data.Avro.Schema        as S
+import           Data.Avro.Types         as T
 import           Data.Avro.Types.Decimal as D
-import qualified Data.ByteString      as B
-import           Data.ByteString.Lazy (ByteString)
-import qualified Data.ByteString.Lazy as BL
-import qualified Data.HashMap.Strict  as HashMap
+import qualified Data.ByteString         as B
+import           Data.ByteString.Lazy    (ByteString)
+import qualified Data.ByteString.Lazy    as BL
+import qualified Data.HashMap.Strict     as HashMap
 import           Data.Int
-import           Data.Ix              (Ix)
-import           Data.List.NonEmpty   (NonEmpty (..))
-import qualified Data.Map             as Map
-import           Data.Monoid          ((<>))
+import           Data.Ix                (Ix)
+import           Data.List.NonEmpty     (NonEmpty (..))
+import qualified Data.Map               as Map
+import           Data.Monoid            ((<>))
 import           Data.Proxy
-import qualified Data.Set             as S
+import qualified Data.Set               as S
 import           Data.Tagged
 import           Data.Text            (Text)
 import qualified Data.Text            as Text
@@ -102,6 +103,9 @@ instance HasAvroSchema Time.DiffTime where
 
 instance HasAvroSchema Time.UTCTime where
   schema = Tagged $ S.Long (Just TimestampMicros)
+
+instance (HasAvroSchema a) => HasAvroSchema (Identity a) where
+  schema = Tagged $ S.Union $ V.fromListN 1 [untag (schema :: Tagged a Schema)]
 
 instance (HasAvroSchema a, HasAvroSchema b) => HasAvroSchema (Either a b) where
   schema = Tagged $ S.Union $ V.fromListN 2 [untag (schema :: Tagged a Schema), untag (schema :: Tagged b Schema)]

--- a/src/Data/Avro/ToAvro.hs
+++ b/src/Data/Avro/ToAvro.hs
@@ -5,6 +5,7 @@ module Data.Avro.ToAvro
 
 where
 
+import           Control.Monad.Identity  (Identity(..))
 import           Control.Arrow           (first)
 import           Data.Avro.HasAvroSchema
 import           Data.Avro.Schema        as S
@@ -80,6 +81,12 @@ instance ToAvro Time.Day where
 
 instance ToAvro Time.DiffTime where
   toAvro = T.Long . fromIntegral . diffTimeToMicros
+
+instance (ToAvro a) => ToAvro (Identity a) where
+  toAvro e@(Identity a) =
+    let sch = options (schemaOf e)
+    in
+      T.Union sch (schemaOf a) (toAvro a)
 
 instance (ToAvro a, ToAvro b) => ToAvro (Either a b) where
   toAvro e =

--- a/test/Avro/JSONSpec.hs
+++ b/test/Avro/JSONSpec.hs
@@ -6,9 +6,10 @@ module Avro.JSONSpec where
 
 import Control.Monad (forM_)
 
-import qualified Data.Aeson           as Aeson
-import qualified Data.ByteString.Lazy as LBS
-import qualified Data.Map             as Map
+import           Control.Monad.Identity (Identity (..))
+import qualified Data.Aeson             as Aeson
+import qualified Data.ByteString.Lazy   as LBS
+import qualified Data.Map               as Map
 
 import Data.Avro.Deriving
 import Data.Avro.EitherN
@@ -75,6 +76,7 @@ spec = describe "Avro.JSONSpec: JSON serialization/parsing" $ do
         , unionsRecords     = Left $ Foo { fooStuff = "stuff" }
         , unionsSameFields  = Left $ Foo { fooStuff = "foo stuff" }
         , unionsArrayAndMap = Left ["foo"]
+        , unionsOne         = Identity 42
         , unionsThree       = E3_1 37
         , unionsFour        = E4_2 "foo"
         , unionsFive        = E5_4 $ Foo { fooStuff = "foo stuff" }
@@ -87,6 +89,7 @@ spec = describe "Avro.JSONSpec: JSON serialization/parsing" $ do
                                           }
         , unionsSameFields  = Right $ NotFoo { notFooStuff = "not foo stuff" }
         , unionsArrayAndMap = Right $ Map.fromList [("a", 5)]
+        , unionsOne         = Identity 42
         , unionsThree       = E3_3 37
         , unionsFour        = E4_4 $ Foo { fooStuff = "foo stuff" }
         , unionsFive        = E5_5 $ NotFoo { notFooStuff = "not foo stuff" }

--- a/test/Avro/THUnionSpec.hs
+++ b/test/Avro/THUnionSpec.hs
@@ -7,15 +7,17 @@ where
 
 import qualified Data.List.NonEmpty as NE
 
-import qualified Data.Aeson           as Aeson
+
+import           Control.Monad.Identity (Identity (..))
+import qualified Data.Aeson             as Aeson
 import           Data.Avro
 import           Data.Avro.Deriving
 import           Data.Avro.EitherN
-import qualified Data.Avro.Schema     as Schema
-import qualified Data.Avro.Types      as Avro
-import qualified Data.ByteString.Lazy as LBS
-import qualified Data.Map             as Map
-import qualified Data.Vector          as V
+import qualified Data.Avro.Schema       as Schema
+import qualified Data.Avro.Types        as Avro
+import qualified Data.ByteString.Lazy   as LBS
+import qualified Data.Map               as Map
+import qualified Data.Vector            as V
 
 import System.Directory (doesFileExist)
 
@@ -33,6 +35,7 @@ spec = describe "Avro.THUnionSpec: Schema with unions." $ do
         , unionsRecords     = Left $ Foo { fooStuff = "stuff" }
         , unionsSameFields  = Left $ Foo { fooStuff = "more stuff" }
         , unionsArrayAndMap = Left ["foo"]
+        , unionsOne         = Identity 42
         , unionsThree       = E3_1 37
         , unionsFour        = E4_2 "foo"
         , unionsFive        = E5_4 $ Foo { fooStuff = "foo stuff" }
@@ -45,6 +48,7 @@ spec = describe "Avro.THUnionSpec: Schema with unions." $ do
                                           }
         , unionsSameFields  = Right $ NotFoo { notFooStuff = "different from Foo" }
         , unionsArrayAndMap = Right $ Map.fromList [("a", 5)]
+        , unionsOne         = Identity 42
         , unionsThree       = E3_3 37
         , unionsFour        = E4_4 $ Foo { fooStuff = "foo stuff" }
         , unionsFive        = E5_5 $ NotFoo { notFooStuff = "not foo stuff" }
@@ -64,6 +68,7 @@ spec = describe "Avro.THUnionSpec: Schema with unions." $ do
         , field "sameFields"  (Schema.mkUnion (NE.fromList [foo, notFooSchema]))          Nothing
         , field "arrayAndMap" (Schema.mkUnion (NE.fromList [array, map]))                 Nothing
 
+        , field "one"   (Schema.mkUnion (NE.fromList [Schema.Int']))                                          Nothing
         , field "three" (Schema.mkUnion (NE.fromList [Schema.Int', Schema.String', Schema.Long']))              Nothing
         , field "four"  (Schema.mkUnion (NE.fromList [Schema.Int', Schema.String', Schema.Long', foo]))         Nothing
         , field "five"  (Schema.mkUnion (NE.fromList [Schema.Int', Schema.String', Schema.Long', foo, notFoo])) Nothing

--- a/test/data/unions-object-a.json
+++ b/test/data/unions-object-a.json
@@ -16,6 +16,7 @@
   "arrayAndMap" : {
     "array" : ["foo"]
   },
+  "one": { "int": 42 },
   "three": { "int": 37 },
   "four": { "string": "foo" },
   "five": {

--- a/test/data/unions-object-b.json
+++ b/test/data/unions-object-b.json
@@ -21,6 +21,7 @@
   "arrayAndMap" : {
     "map" : { "a" : 5 }
   },
+  "one": { "int": 42 },
   "three": { "long": 37 },
   "four": {
     "haskell.avro.example.Foo": { "stuff" : "foo stuff" }

--- a/test/data/unions.avsc
+++ b/test/data/unions.avsc
@@ -54,6 +54,7 @@
         }
       ]
     },
+    { "name" : "one", "type" : ["int"] },
     { "name" : "three", "type" : ["int", "string", "long"] },
     { "name" : "four", "type" : ["int", "string", "long", "Foo"] },
     { "name" : "five", "type" : ["int", "string", "long", "Foo", "NotFoo"] }


### PR DESCRIPTION
There seems to be a hole in the handling of union types in the TemplateHaskell derivation of the Avro types. Namely, there is an unstated assumption that the size of the unions are at least 2.
Moreover, running `deriveAvro` on an .avsc schema that contains exactly one constructor results in the confusing error message 
> Unions with more than 5 elements are not yet supported.

Avro unions with a single constructor aren't explicitly mentioned in the specification, but it does say that 
> Unions [...] are represented [in schemata] using JSON arrays

which does not rule out the length 1 array case. This is corroborated by the reference implementation used by `avro-tools`, which does generate length 1 arrays from `.avdl` schemata containing `union` declarations with a single element.

This PR modifies `deriveAvro` to wrap such unions in the `Identity` functor, serving as the degenerate case of the `EitherN` collection of types. It also provides more helpful error messages for union types
with an unsupported number of constructors.

I wasn't sure if using `Identity` is the best way to deal with this, or if you would prefer an `Either1` newtype, but this can be easily changed!