### PR TITLE
Add logical types (decimal, UUID, dates)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ cabal.config
 .stack-work/
 .ghc.ennvironment*
 cabal.project.local
+stack.yaml.lock
 
 # Emacs files
 *~

--- a/avro.cabal
+++ b/avro.cabal
@@ -55,6 +55,7 @@ common array                    { build-depends: array                          
 common avro                     { build-depends: avro                                               }
 common base16-bytestring        { build-depends: base16-bytestring                                  }
 common bifunctors               { build-depends: bifunctors                                         }
+common big-decimal              { build-depends: HasBigDecimal                                      }
 common binary                   { build-depends: binary                                             }
 common bytestring               { build-depends: bytestring                                         }
 common containers               { build-depends: containers                                         }
@@ -78,9 +79,11 @@ common scientific               { build-depends: scientific                     
 common semigroups               { build-depends: semigroups                                         }
 common tagged                   { build-depends: tagged                                             }
 common text                     { build-depends: text                     >= 1.2.3      && < 1.3    }
+common time                     { build-depends: time                                               }
 common tf-random                { build-depends: tf-random                                          }
 common transformers             { build-depends: transformers                                       }
 common unordered-containers     { build-depends: unordered-containers                               }
+common uuid                     { build-depends: uuid                                               }
 common vector                   { build-depends: vector                                             }
 common zlib                     { build-depends: zlib                                               }
 
@@ -98,6 +101,7 @@ library
                       , array
                       , base16-bytestring
                       , bifunctors
+                      , big-decimal
                       , binary
                       , bytestring
                       , containers
@@ -111,8 +115,10 @@ library
                       , semigroups
                       , tagged
                       , text
+                      , time
                       , tf-random
                       , unordered-containers
+                      , uuid
                       , vector
                       , zlib
   exposed-modules:      Data.Avro
@@ -140,9 +146,11 @@ library
                         Data.Avro.Schema
                         Data.Avro.ToAvro
                         Data.Avro.Types
+                        Data.Avro.Types.Decimal
                         Data.Avro.Types.Value
                         Data.Avro.Zag
                         Data.Avro.Zig
+  other-modules:        Data.Avro.Types.Time
   hs-source-dirs:       src
   other-extensions:     OverloadedStrings
 
@@ -153,6 +161,7 @@ test-suite test
                       , avro
                       , base16-bytestring
                       , bifunctors
+                      , big-decimal
                       , binary
                       , bytestring
                       , containers
@@ -172,8 +181,10 @@ test-suite test
                       , tagged
                       , text
                       , tf-random
+                      , time
                       , transformers
                       , unordered-containers
+                      , uuid
                       , vector
   type:                 exitcode-stdio-1.0
   ghc-options:          -threaded

--- a/bench/Bench/Time.hs
+++ b/bench/Bench/Time.hs
@@ -61,8 +61,8 @@ encodeArray = env randoms $ \ ~(bools, ints, longs, records) ->
           ]
         recordSchema = Schema.Record "Rec" [] Nothing Nothing
           [ Schema.Field "b" [] Nothing Nothing Schema.Boolean Nothing
-          , Schema.Field "i" [] Nothing Nothing Schema.Int Nothing
-          , Schema.Field "l" [] Nothing Nothing Schema.Long Nothing
+          , Schema.Field "i" [] Nothing Nothing Schema.Int' Nothing
+          , Schema.Field "l" [] Nothing Nothing Schema.Long' Nothing
           ]
 
 encodeAvro :: Value Schema -> LBS.ByteString
@@ -79,9 +79,9 @@ decodeArray = env randoms $ \ ~(bools, ints, longs, records) ->
   [ bench "bools" $
       nf (decodeAvro $ Schema.Array Schema.Boolean) bools
   , bench "ints" $
-      nf (decodeAvro $ Schema.Array Schema.Int) ints
+      nf (decodeAvro $ Schema.Array Schema.Int') ints
   , bench "longs" $
-      nf (decodeAvro $ Schema.Array Schema.Long) longs
+      nf (decodeAvro $ Schema.Array Schema.Long') longs
   , bench "records" $
       nf (decodeAvro $ Schema.Array recordSchema) records
   ]
@@ -107,8 +107,8 @@ decodeArray = env randoms $ \ ~(bools, ints, longs, records) ->
           ]
         recordSchema = Schema.Record "Rec" [] Nothing Nothing
           [ Schema.Field "b" [] Nothing Nothing Schema.Boolean Nothing
-          , Schema.Field "i" [] Nothing Nothing Schema.Int Nothing
-          , Schema.Field "l" [] Nothing Nothing Schema.Long Nothing
+          , Schema.Field "i" [] Nothing Nothing Schema.Int' Nothing
+          , Schema.Field "l" [] Nothing Nothing Schema.Long' Nothing
           ]
 
 decodeAvro :: Schema -> LBS.ByteString -> Value Schema

--- a/src/Data/Avro/Decode/Lazy.hs
+++ b/src/Data/Avro/Decode/Lazy.hs
@@ -294,16 +294,16 @@ getAvroOf ty0 bs = go ty0 bs
   go :: Schema -> BL.ByteString -> (BL.ByteString, T.LazyValue Schema)
   go ty bs =
     case ty of
-      Null    -> (bs, T.Null)
-      Boolean -> decodeGet T.Boolean  bs
-      Int     -> decodeGet T.Int      bs
-      Long    -> decodeGet T.Long     bs
-      Float   -> decodeGet T.Float    bs
-      Double  -> decodeGet T.Double   bs
-      Bytes   -> decodeGet T.Bytes    bs
-      String  -> decodeGet T.String   bs
-      Array t -> T.Array . V.fromList . mconcat <$> getElements bs (go t)
-      Map t   -> T.Map . HashMap.fromList . mconcat <$> getKVPairs bs (go t)
+      Null     -> (bs, T.Null)
+      Boolean  -> decodeGet T.Boolean  bs
+      Int _    -> decodeGet T.Int      bs
+      Long _   -> decodeGet T.Long     bs
+      Float    -> decodeGet T.Float    bs
+      Double   -> decodeGet T.Double   bs
+      Bytes _  -> decodeGet T.Bytes    bs
+      String _ -> decodeGet T.String   bs
+      Array t  -> T.Array . V.fromList . mconcat <$> getElements bs (go t)
+      Map t    -> T.Map . HashMap.fromList . mconcat <$> getKVPairs bs (go t)
       NamedType tn ->
         case runGetOrFail (env tn) bs of
           Left (bs', _, err) -> (bs', T.Error err)

--- a/src/Data/Avro/Decode/Lazy/Deconflict.hs
+++ b/src/Data/Avro/Decode/Lazy/Deconflict.hs
@@ -78,15 +78,15 @@ deconflictValue writerSchema readerSchema v
         withSchemaIn tyVal xs $ \sch -> deconflictValue sch nonUnion val
     go eTy dTy val =
       case val of
-        T.Int i32  | dTy == S.Long   -> T.Long   (fromIntegral i32)
-                   | dTy == S.Float  -> T.Float  (fromIntegral i32)
-                   | dTy == S.Double -> T.Double (fromIntegral i32)
-        T.Long i64 | dTy == S.Float  -> T.Float (fromIntegral i64)
-                   | dTy == S.Double -> T.Double (fromIntegral i64)
-        T.Float f  | dTy == S.Double -> T.Double (realToFrac f)
-        T.String s | dTy == S.Bytes  -> T.Bytes (Text.encodeUtf8 s)
-        T.Bytes bs | dTy == S.String -> T.String (Text.decodeUtf8 bs)
-        _                            -> T.Error $ "Can not resolve differing writer and reader schemas: " ++ show (eTy, dTy)
+        T.Int i32  | S.Long _ <- dTy   -> T.Long   (fromIntegral i32)
+                   | dTy == S.Float    -> T.Float  (fromIntegral i32)
+                   | dTy == S.Double   -> T.Double (fromIntegral i32)
+        T.Long i64 | dTy == S.Float    -> T.Float (fromIntegral i64)
+                   | dTy == S.Double   -> T.Double (fromIntegral i64)
+        T.Float f  | dTy == S.Double   -> T.Double (realToFrac f)
+        T.String s | S.Bytes _ <- dTy  -> T.Bytes (Text.encodeUtf8 s)
+        T.Bytes bs | S.String _ <- dTy -> T.String (Text.decodeUtf8 bs)
+        _                              -> T.Error $ "Can not resolve differing writer and reader schemas: " ++ show (eTy, dTy)
 
 -- The writer's symbol must be present in the reader's enum
 deconflictEnum :: Schema -> Schema -> T.LazyValue Schema -> T.LazyValue Schema

--- a/src/Data/Avro/Decode/Strict/Internal.hs
+++ b/src/Data/Avro/Decode/Strict/Internal.hs
@@ -48,18 +48,18 @@ getAvroOf ty0 = go ty0
  go :: Schema -> Get (T.Value Schema)
  go ty =
   case ty of
-    Null    -> return T.Null
-    Boolean -> T.Boolean <$> getAvro
-    Int     -> T.Int     <$> getAvro
-    Long    -> T.Long    <$> getAvro
-    Float   -> T.Float   <$> getAvro
-    Double  -> T.Double  <$> getAvro
-    Bytes   -> T.Bytes   <$> getAvro
-    String  -> T.String  <$> getAvro
-    Array t ->
+    Null     -> return T.Null
+    Boolean  -> T.Boolean <$> getAvro
+    Int _    -> T.Int     <$> getAvro
+    Long _   -> T.Long    <$> getAvro
+    Float    -> T.Float   <$> getAvro
+    Double   -> T.Double  <$> getAvro
+    Bytes _  -> T.Bytes   <$> getAvro
+    String _ -> T.String  <$> getAvro
+    Array t  ->
       do vals <- getBlocksOf t
          return $ T.Array (V.fromList $ mconcat vals)
-    Map  t  ->
+    Map  t   ->
       do kvs <- getKVBlocks t
          return $ T.Map (HashMap.fromList $ mconcat kvs)
     NamedType tn -> env tn >>= go

--- a/src/Data/Avro/Deconflict.hs
+++ b/src/Data/Avro/Deconflict.hs
@@ -80,15 +80,15 @@ deconflictValue writerSchema readerSchema v
        withSchemaIn tyVal xs $ \sch -> deconflictValue sch nonUnion val
   go eTy dTy val =
     case val of
-      T.Int i32  | dTy == S.Long   -> Right $ T.Long   (fromIntegral i32)
-                 | dTy == S.Float  -> Right $ T.Float  (fromIntegral i32)
-                 | dTy == S.Double -> Right $ T.Double (fromIntegral i32)
-      T.Long i64 | dTy == S.Float  -> Right $ T.Float (fromIntegral i64)
-                 | dTy == S.Double -> Right $ T.Double (fromIntegral i64)
-      T.Float f  | dTy == S.Double -> Right $ T.Double (realToFrac f)
-      T.String s | dTy == S.Bytes  -> Right $ T.Bytes (Text.encodeUtf8 s)
-      T.Bytes bs | dTy == S.String -> Right $ T.String (Text.decodeUtf8 bs)
-      _                            -> Left $ "Can not resolve differing writer and reader schemas: " ++ show (eTy, dTy)
+      T.Int i32  | S.Long _ <- dTy   -> Right $ T.Long   (fromIntegral i32)
+                 | dTy == S.Float    -> Right $ T.Float  (fromIntegral i32)
+                 | dTy == S.Double   -> Right $ T.Double (fromIntegral i32)
+      T.Long i64 | dTy == S.Float    -> Right $ T.Float (fromIntegral i64)
+                 | dTy == S.Double   -> Right $ T.Double (fromIntegral i64)
+      T.Float f  | dTy == S.Double   -> Right $ T.Double (realToFrac f)
+      T.String s | S.Bytes _ <- dTy  -> Right $ T.Bytes (Text.encodeUtf8 s)
+      T.Bytes bs | S.String _ <- dTy -> Right $ T.String (Text.decodeUtf8 bs)
+      _                              -> Left $ "Can not resolve differing writer and reader schemas: " ++ show (eTy, dTy)
 
 -- The writer's symbol must be present in the reader's enum
 deconflictEnum :: Schema -> Schema -> T.Value Schema -> Either String (T.Value Schema)

--- a/src/Data/Avro/Deriving/Lift.hs
+++ b/src/Data/Avro/Deriving/Lift.hs
@@ -34,4 +34,10 @@ deriving instance Lift f => Lift (Avro.Value f)
 deriving instance Lift Schema.Field
 deriving instance Lift Schema.Order
 deriving instance Lift Schema.TypeName
+deriving instance Lift Schema.Decimal
+deriving instance Lift Schema.LogicalTypeBytes
+deriving instance Lift Schema.LogicalTypeFixed
+deriving instance Lift Schema.LogicalTypeInt
+deriving instance Lift Schema.LogicalTypeLong
+deriving instance Lift Schema.LogicalTypeString
 deriving instance Lift Schema.Schema

--- a/src/Data/Avro/HasAvroSchema.hs
+++ b/src/Data/Avro/HasAvroSchema.hs
@@ -1,12 +1,12 @@
 {-# LANGUAGE ConstraintKinds      #-}
 {-# LANGUAGE FlexibleInstances    #-}
 {-# LANGUAGE ScopedTypeVariables  #-}
-{-# LANGUAGE TypeSynonymInstances #-}
 module Data.Avro.HasAvroSchema where
 
 import qualified Data.Array           as Ar
 import           Data.Avro.Schema     as S
 import           Data.Avro.Types      as T
+import           Data.Avro.Types.Decimal as D
 import qualified Data.ByteString      as B
 import           Data.ByteString.Lazy (ByteString)
 import qualified Data.ByteString.Lazy as BL
@@ -22,9 +22,12 @@ import           Data.Tagged
 import           Data.Text            (Text)
 import qualified Data.Text            as Text
 import qualified Data.Text.Lazy       as TL
+import qualified Data.Time            as Time
+import qualified Data.UUID            as UUID
 import qualified Data.Vector          as V
 import qualified Data.Vector.Unboxed  as U
 import           Data.Word
+import           GHC.TypeLits
 
 class HasAvroSchema a where
   schema :: Tagged a Schema
@@ -33,16 +36,16 @@ schemaOf :: (HasAvroSchema a) => a -> Schema
 schemaOf = witness schema
 
 instance HasAvroSchema Word8 where
-  schema = Tagged S.Int
+  schema = Tagged S.Int'
 
 instance HasAvroSchema Word16 where
-  schema = Tagged S.Int
+  schema = Tagged S.Int'
 
 instance HasAvroSchema Word32 where
-  schema = Tagged S.Long
+  schema = Tagged S.Long'
 
 instance HasAvroSchema Word64 where
-  schema = Tagged S.Long
+  schema = Tagged S.Long'
 
 instance HasAvroSchema Bool where
   schema = Tagged S.Boolean
@@ -51,19 +54,19 @@ instance HasAvroSchema () where
   schema = Tagged S.Null
 
 instance HasAvroSchema Int where
-  schema = Tagged S.Long
+  schema = Tagged S.Long'
 
 instance HasAvroSchema Int8 where
-  schema = Tagged S.Int
+  schema = Tagged S.Int'
 
 instance HasAvroSchema Int16 where
-  schema = Tagged S.Int
+  schema = Tagged S.Int'
 
 instance HasAvroSchema Int32 where
-  schema = Tagged S.Int
+  schema = Tagged S.Int'
 
 instance HasAvroSchema Int64 where
-  schema = Tagged S.Long
+  schema = Tagged S.Long'
 
 instance HasAvroSchema Double where
   schema = Tagged S.Double
@@ -72,16 +75,33 @@ instance HasAvroSchema Float where
   schema = Tagged S.Float
 
 instance HasAvroSchema Text.Text where
-  schema = Tagged S.String
+  schema = Tagged S.String'
 
 instance HasAvroSchema TL.Text where
-  schema = Tagged S.String
+  schema = Tagged S.String'
 
 instance HasAvroSchema B.ByteString where
-  schema = Tagged S.Bytes
+  schema = Tagged S.Bytes'
 
 instance HasAvroSchema BL.ByteString where
-  schema = Tagged S.Bytes
+  schema = Tagged S.Bytes'
+
+instance (KnownNat p, KnownNat s) => HasAvroSchema (D.Decimal p s) where
+  schema = Tagged $ S.Long (Just (DecimalL (S.Decimal pp ss)))
+    where ss = natVal (Proxy :: Proxy s)
+          pp = natVal (Proxy :: Proxy p)
+
+instance HasAvroSchema UUID.UUID where
+  schema = Tagged $ S.String (Just UUID)
+
+instance HasAvroSchema Time.Day where
+  schema = Tagged $ S.Int (Just Date)
+
+instance HasAvroSchema Time.DiffTime where
+  schema = Tagged $ S.Long (Just TimeMicros)
+
+instance HasAvroSchema Time.UTCTime where
+  schema = Tagged $ S.Long (Just TimestampMicros)
 
 instance (HasAvroSchema a, HasAvroSchema b) => HasAvroSchema (Either a b) where
   schema = Tagged $ S.Union $ V.fromListN 2 [untag (schema :: Tagged a Schema), untag (schema :: Tagged b Schema)]

--- a/src/Data/Avro/Types/Decimal.hs
+++ b/src/Data/Avro/Types/Decimal.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE PolyKinds                  #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+module Data.Avro.Types.Decimal where
+
+import qualified Data.BigDecimal as D
+import           Data.Proxy
+import           GHC.TypeLits
+
+newtype Decimal (p :: Nat) (s :: Nat)
+  = Decimal { unDecimal :: D.BigDecimal }
+  deriving (Eq, Ord, Show, Read, Num, Fractional, Real)
+
+fromUnderlyingValue
+  :: forall p s. KnownNat s
+  => Integer -> Decimal p s
+fromUnderlyingValue n
+  = Decimal $ D.BigDecimal n (natVal (Proxy :: Proxy s))
+
+underlyingValue
+  :: forall s p. (KnownNat p, KnownNat s)
+  => Decimal p s -> Maybe Int
+underlyingValue (Decimal d)
+  = let ss = natVal (Proxy :: Proxy s)
+        pp = natVal (Proxy :: Proxy p)
+        new = if ss > D.getScale d
+                 then D.BigDecimal (D.getValue d * 10 ^ (ss - D.getScale d)) ss
+                 else D.roundBD d (D.halfUp ss)
+    in if D.precision new > pp
+          then Nothing
+          else Just $ fromInteger $ D.getValue new

--- a/src/Data/Avro/Types/Time.hs
+++ b/src/Data/Avro/Types/Time.hs
@@ -1,0 +1,23 @@
+module Data.Avro.Types.Time where
+
+-- Utility functions to work with times
+
+import Data.Maybe (fromJust)
+import Data.Time
+import Data.Time.Clock
+import Data.Time.Format
+
+epochDate :: Day
+epochDate = fromJust $ buildTime defaultTimeLocale []
+
+daysSinceEpoch :: Day -> Integer
+daysSinceEpoch d = diffDays d epochDate
+
+fromDaysSinceEpoch :: Integer -> Day
+fromDaysSinceEpoch n = addDays n epochDate
+
+diffTimeToMicros :: DiffTime -> Integer
+diffTimeToMicros = (`div` 1000000) . diffTimeToPicoseconds
+
+microsToDiffTime :: Integer -> DiffTime
+microsToDiffTime = picosecondsToDiffTime . (* 1000000)

--- a/src/Data/Avro/Types/Time.hs
+++ b/src/Data/Avro/Types/Time.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 module Data.Avro.Types.Time where
 
 -- Utility functions to work with times
@@ -5,7 +6,11 @@ module Data.Avro.Types.Time where
 import Data.Maybe (fromJust)
 import Data.Time
 import Data.Time.Clock
+#if MIN_VERSION_time(1,9,0)
+import Data.Time.Format.Internal
+#else
 import Data.Time.Format
+#endif
 
 epochDate :: Day
 epochDate = fromJust $ buildTime defaultTimeLocale []

--- a/test/Avro/Codec/Int64Spec.hs
+++ b/test/Avro/Codec/Int64Spec.hs
@@ -34,7 +34,7 @@ onlyInt64Schema :: Schema
 onlyInt64Schema =
   let fld nm = Field nm [] Nothing Nothing
    in Record "test.contract.OnlyInt64" [] Nothing Nothing
-        [ fld "onlyInt64Value"    Long Nothing
+        [ fld "onlyInt64Value"    Long' Nothing
         ]
 
 instance HasAvroSchema OnlyInt64 where

--- a/test/Avro/Codec/NestedSpec.hs
+++ b/test/Avro/Codec/NestedSpec.hs
@@ -25,15 +25,15 @@ childTypeSchema :: Schema
 childTypeSchema =
   let fld nm = Field nm [] Nothing Nothing
   in Record "test.contract.ChildType" [] Nothing Nothing
-        [ fld "childValue1" Long Nothing
-        , fld "childValue2" Long Nothing
+        [ fld "childValue1" Long' Nothing
+        , fld "childValue2" Long' Nothing
         ]
 
 parentTypeSchema :: Schema
 parentTypeSchema =
   let fld nm = Field nm [] Nothing Nothing
   in Record "test.contract.ParentType" [] Nothing Nothing
-        [ fld "parentValue1" Long             Nothing
+        [ fld "parentValue1" Long'             Nothing
         , fld "parentValue2" (Array childTypeSchema)  Nothing]
 
 instance HasAvroSchema ParentType where

--- a/test/Avro/Codec/TextSpec.hs
+++ b/test/Avro/Codec/TextSpec.hs
@@ -22,7 +22,7 @@ onlyTextSchema :: Schema
 onlyTextSchema =
   let fld nm = Field nm [] Nothing Nothing
   in Record "test.contract.OnlyText" [] Nothing Nothing
-        [ fld "onlyTextValue" String Nothing
+        [ fld "onlyTextValue" String' Nothing
         ]
 
 instance HasAvroSchema OnlyText where

--- a/test/Avro/DefaultsSpec.hs
+++ b/test/Avro/DefaultsSpec.hs
@@ -35,7 +35,7 @@ spec = describe "Avro.DefaultsSpec: Schema with named types" $ do
       msgSchema = schemaOf (undefined :: MaybeTest)
       fixedSchema = schemaOf (undefined :: FixedTag)
       defaults = fldDefault <$> fields msgSchema
-    in defaults `shouldBe` [ Just $ Ty.Union (V.fromList [Null, String]) Null Ty.Null
+    in defaults `shouldBe` [ Just $ Ty.Union (V.fromList [Null, String']) Null Ty.Null
                            , Just $ Ty.Fixed fixedSchema "\0\42\255"
                            , Just $ Ty.Bytes "\0\37\255"
                            ]

--- a/test/Avro/THUnionSpec.hs
+++ b/test/Avro/THUnionSpec.hs
@@ -58,28 +58,28 @@ spec = describe "Avro.THUnionSpec: Schema with unions." $ do
       foo    = named "haskell.avro.example.Foo"
       notFoo = named "haskell.avro.example.NotFoo"
       expectedSchema = record "haskell.avro.example.Unions"
-        [ field "scalars"     (Schema.mkUnion (NE.fromList [Schema.String, Schema.Long])) scalarsDefault
-        , field "nullable"    (Schema.mkUnion (NE.fromList [Schema.Null, Schema.Int]))    nullableDefault
+        [ field "scalars"     (Schema.mkUnion (NE.fromList [Schema.String', Schema.Long'])) scalarsDefault
+        , field "nullable"    (Schema.mkUnion (NE.fromList [Schema.Null, Schema.Int']))    nullableDefault
         , field "records"     (Schema.mkUnion (NE.fromList [fooSchema, barSchema]))       Nothing
         , field "sameFields"  (Schema.mkUnion (NE.fromList [foo, notFooSchema]))          Nothing
         , field "arrayAndMap" (Schema.mkUnion (NE.fromList [array, map]))                 Nothing
 
-        , field "three" (Schema.mkUnion (NE.fromList [Schema.Int, Schema.String, Schema.Long]))              Nothing
-        , field "four"  (Schema.mkUnion (NE.fromList [Schema.Int, Schema.String, Schema.Long, foo]))         Nothing
-        , field "five"  (Schema.mkUnion (NE.fromList [Schema.Int, Schema.String, Schema.Long, foo, notFoo])) Nothing
+        , field "three" (Schema.mkUnion (NE.fromList [Schema.Int', Schema.String', Schema.Long']))              Nothing
+        , field "four"  (Schema.mkUnion (NE.fromList [Schema.Int', Schema.String', Schema.Long', foo]))         Nothing
+        , field "five"  (Schema.mkUnion (NE.fromList [Schema.Int', Schema.String', Schema.Long', foo, notFoo])) Nothing
         ]
-      scalarsDefault  = Just $ Avro.Union (V.fromList [Schema.String, Schema.Long]) Schema.String (Avro.String "foo")
-      nullableDefault = Just $ Avro.Union (V.fromList [Schema.Null, Schema.Int])    Schema.Null   Avro.Null
+      scalarsDefault  = Just $ Avro.Union (V.fromList [Schema.String', Schema.Long']) Schema.String' (Avro.String "foo")
+      nullableDefault = Just $ Avro.Union (V.fromList [Schema.Null, Schema.Int'])    Schema.Null   Avro.Null
 
-      fooSchema = record "haskell.avro.example.Foo" [field "stuff" Schema.String Nothing]
+      fooSchema = record "haskell.avro.example.Foo" [field "stuff" Schema.String' Nothing]
       barSchema = record "haskell.avro.example.Bar"
-        [ field "stuff"  Schema.String Nothing
+        [ field "stuff"  Schema.String' Nothing
         , field "things" (named "haskell.avro.example.Foo") Nothing
         ]
-      notFooSchema = record "haskell.avro.example.NotFoo" [field "stuff" Schema.String Nothing]
+      notFooSchema = record "haskell.avro.example.NotFoo" [field "stuff" Schema.String' Nothing]
 
-      array = Schema.Array { Schema.item = Schema.String }
-      map   = Schema.Map { Schema.values = Schema.Long }
+      array = Schema.Array { Schema.item = Schema.String' }
+      map   = Schema.Map { Schema.values = Schema.Long' }
 
   unionsSchemaFile <- runIO $ getFileName "test/data/unions.avsc" >>= LBS.readFile
   let Just unionsSchemaFromJSON = Aeson.decode unionsSchemaFile

--- a/test/Avro/ToAvroSpec.hs
+++ b/test/Avro/ToAvroSpec.hs
@@ -33,10 +33,10 @@ tmSchema :: Schema
 tmSchema =
   let fld nm = Field nm [] Nothing Nothing
    in Record "avro.haskell.test.TypesTestMessage" [] Nothing Nothing
-        [ fld "id" Long Nothing
-        , fld "name" String Nothing
-        , fld "timestamp" (mkUnion (Null :| [Long])) Nothing
-        , fld "foreignId" (mkUnion (Null :| [Long])) Nothing
+        [ fld "id" Long' Nothing
+        , fld "name" String' Nothing
+        , fld "timestamp" (mkUnion (Null :| [Long'])) Nothing
+        , fld "foreignId" (mkUnion (Null :| [Long'])) Nothing
         , fld "competence" (mkUnion (Null :| [Double])) Nothing
         , fld "relevance" (mkUnion (Null :| [Float])) Nothing
         , fld "severity" Float Nothing

--- a/test/Example1.hs
+++ b/test/Example1.hs
@@ -23,11 +23,11 @@ msSchema  :: Schema
 msSchema =
   Record "MyStruct" [] Nothing Nothing
       [ fld "enumOrString" eOrS (Just $ Ty.String "The Default")
-      , fld "intvalue" Long Nothing
+      , fld "intvalue" Long' Nothing
       ]
      where
      fld nm ty def = Field nm [] Nothing Nothing ty def
-     eOrS = mkUnion (meSchema :| [String])
+     eOrS = mkUnion (meSchema :| [String'])
 
 -- Encoding data, via the ToAvro class, requires both the routine that encodes
 -- data as well as the schema under which it is encoded.  The encoding and


### PR DESCRIPTION
Fixes #68

This PR adds support for encoding information about logical types in the schema, and also conversion from some of the underlying types to Avro.

Note that the PR implements some things out of the spec (for example, the conversion from `decimal` to `long`), but this seems to be supported in the Java Avro library, so we have those for compatibility.