### PR TITLE
Consider adding derived Ord instances

### DIFF
--- a/src/Data/Avro/Types/Value.hs
+++ b/src/Data/Avro/Types/Value.hs
@@ -28,4 +28,4 @@ data Value f
       | Union (Vector f) f (Value f) -- ^ Set of union options, schema for selected option, and the actual value.
       | Fixed f {-# UNPACK #-} !ByteString
       | Enum f {-# UNPACK #-} !Int Text  -- ^ An enum is a set of the possible symbols (the schema) and the selected symbol
-  deriving (Eq, Show, Generic, NFData)
+  deriving (Eq, Ord, Show, Generic, NFData)


### PR DESCRIPTION
Hi!

We have a scenario in which we are using `Data.Avro.Schema` inside a **Set** to avoid duplicated entries, and had to manually provide `Ord` instances for everything (here: https://github.com/higherkindness/avro-parser-haskell/blob/master/src/Language/Avro/Types.hs#L36-L52).

Maybe you can consider adding this if it is not too invasive? 😄 

Also, we'd like to know (@serras and me) if there's any ETA on the next release which contains the logical types, since we'd love to publish the newest version of our library using those changes! 😉 