### PR TITLE
Add functionality for customizing derived Haskell type names

### DIFF
--- a/src/Data/Avro/Deriving.hs
+++ b/src/Data/Avro/Deriving.hs
@@ -97,6 +97,11 @@ data NamespaceBehavior =
     -- @Com'example'Foo@. If @Foo@ had a field called @bar@, the
     -- generated Haskell record would have the field
     -- @com'example'FooBar@.
+  | Custom (T.Text -> [T.Text] -> T.Text)
+    -- ^ Provide a custom mapping from the name of the Avro type and
+    -- its namespace that will be used to generate Haskell types and
+    -- fields.
+
 
 -- | Describes the strictness of a field for a derived
 -- data type. The field will be derived as if it were
@@ -575,6 +580,7 @@ renderName :: NamespaceBehavior
 renderName namespaceBehavior (TN name namespace) = case namespaceBehavior of
   HandleNamespaces -> Text.intercalate "'" $ namespace <> [name]
   IgnoreNamespaces -> name
+  Custom f -> f name namespace
 
 mkSchemaValueName :: NamespaceBehavior -> TypeName -> Name
 mkSchemaValueName namespaceBehavior typeName =


### PR DESCRIPTION
Introduces a third way to handle Avro namespaces, namely by providing your own function to map namespaced Avro types to Haskell types.

This provides a middle ground between `IgnoreNamespaces` (doesn't handle name clashes) and `HandleNamespaces` (very very verbose), allowing you to do for example:

```haskell
disambiguateOffendingType :: Text -> [Text] -> Text
disambiguateOffendingType t ns
  | ns <> [t] == ["some", "namespace", "somewhere" "OffendingType"] = "OffendingType"
  | ns <> [t] == ["some", "other", "namespace", "using", "the", "same", "type", "name", "for", "whatever", "reason", "OffendingType"] = "OffendingTypeOther"
  | otherwise = t
```
Used like so:
```haskell
deriveAvroWithOptions defaultOptions { namespaceBehavior = Custom disambiguateOffendingType } "my-avro-file.avsc"
```