### PR TITLE
Import stuff from base instead of mtl

### DIFF
--- a/src/Data/Avro/Schema/Schema.hs
+++ b/src/Data/Avro/Schema/Schema.hs
@@ -61,6 +61,7 @@ module Data.Avro.Schema.Schema
 
 import           Control.Applicative
 import           Control.DeepSeq            (NFData)
+import           Control.Monad
 import           Control.Monad.Except
 import qualified Control.Monad.Fail         as MF
 import           Control.Monad.State.Strict


### PR DESCRIPTION
There is an intention to stop re-exporting functions from `base` in future versions of `mtl`: https://github.com/haskell/mtl/pull/74
This PR brings `avro` in line with the proposed change.