### PR TITLE
Compatibility with Aeson 2.0

### DIFF
--- a/avro.cabal
+++ b/avro.cabal
@@ -46,7 +46,7 @@ flag dev
 
 common base                     { build-depends: base                     >= 4          && < 5      }
 
-common aeson                    { build-depends: aeson                                              }
+common aeson                    { build-depends: aeson                    >= 2.0.1.0                }
 common array                    { build-depends: array                                              }
 common base16-bytestring        { build-depends: base16-bytestring                                  }
 common bifunctors               { build-depends: bifunctors                                         }

--- a/test/Avro/DefaultsSpec.hs
+++ b/test/Avro/DefaultsSpec.hs
@@ -4,6 +4,7 @@ module Avro.DefaultsSpec
 where
 
 import qualified Data.Aeson              as J
+import qualified Data.Aeson.KeyMap       as KM
 import           Data.Avro.Schema.Schema
 import qualified Data.HashMap.Strict     as M
 import           Data.List.NonEmpty      (NonEmpty (..))
@@ -36,6 +37,6 @@ spec = describe "Avro.DefaultsSpec: Schema with named types" $ do
     let
       msgSchema = schema'MaybeTest
       (J.Object jSchema) = J.toJSON msgSchema
-      (Just (J.Array flds)) = M.lookup "fields" jSchema
+      (Just (J.Array flds)) = KM.lookup "fields" jSchema
       (J.Object jFld) = V.head flds
-    in M.lookup "default" jFld `shouldBe` Just J.Null
+    in KM.lookup "default" jFld `shouldBe` Just J.Null


### PR DESCRIPTION
We are trying to bump Aeson in our internal codebase. 

This PR drops compatibility with older versions of Aeson. Let me know if you think it'd make sense to add some CPP magic to support old versions still.

Fixes https://github.com/haskell-works/avro/issues/170.