### PR TITLE
Add logical local-timestamp types

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,28 +196,30 @@ Full list can be found in `ToAvro` and `FromAvro` modules.
 
 This library provides the following conversions between Haskell types and Avro types:
 
-| Haskell type      | Avro type                                               |
-|:------------------|:--------------------------------------------------------|
-| ()                | "null"                                                  |
-| Bool              | "boolean"                                               |
-| Int, Int64        | "long"                                                  |
-| Int32             | "int"                                                   |
-| Double            | "double"                                                |
-| Text              | "string"                                                |
-| ByteString        | "bytes"                                                 |
-| Maybe a           | ["null", "a"]                                           |
-| Either a b        | ["a", "b"]                                              |
-| Identity a        | ["a"]                                                   |
-| Map Text a        | { "type": "map",    "value": "a" }                      |
-| Map String a      | { "type": "map",    "value": "a" }                      |
-| HashMap Text a    | { "type": "map",    "value": "a" }                      |
-| HashMap String a  | { "type": "map",    "value": "a" }                      |
-| [a]               | { "type": "array",  "value": "a" }                      |
-| UTCTime           | { "type": "long",   "logicalType": "timestamp-millis" } |
-| UTCTime           | { "type": "long",   "logicalType": "timestamp-micros" } |
-| DiffTime          | { "type": "int",    "logicalType": "time-millis" }      |
-| DiffTime          | { "type": "long",   "logicalType": "time-micros" }      |
-| Day               | { "type": "int",    "logicalType": "date" }             |
-| UUID              | { "type": "string", "logicalType": "uuid" }             |
+| Haskell type     | Avro type                                                     |
+|:-----------------|:--------------------------------------------------------------|
+| ()               | "null"                                                        |
+| Bool             | "boolean"                                                     |
+| Int, Int64       | "long"                                                        |
+| Int32            | "int"                                                         |
+| Double           | "double"                                                      |
+| Text             | "string"                                                      |
+| ByteString       | "bytes"                                                       |
+| Maybe a          | ["null", "a"]                                                 |
+| Either a b       | ["a", "b"]                                                    |
+| Identity a       | ["a"]                                                         |
+| Map Text a       | { "type": "map",    "value": "a" }                            |
+| Map String a     | { "type": "map",    "value": "a" }                            |
+| HashMap Text a   | { "type": "map",    "value": "a" }                            |
+| HashMap String a | { "type": "map",    "value": "a" }                            |
+| [a]              | { "type": "array",  "value": "a" }                            |
+| UTCTime          | { "type": "long",   "logicalType": "timestamp-millis" }       |
+| UTCTime          | { "type": "long",   "logicalType": "timestamp-micros" }       |
+| LocalTime        | { "type": "long",   "logicalType": "local-timestamp-millis" } |
+| LocalTime        | { "type": "long",   "logicalType": "local-timestamp-micros" } |
+| DiffTime         | { "type": "int",    "logicalType": "time-millis" }            |
+| DiffTime         | { "type": "long",   "logicalType": "time-micros" }            |
+| Day              | { "type": "int",    "logicalType": "date" }                   |
+| UUID             | { "type": "string", "logicalType": "uuid" }                   |
 
 User defined data types should provide `HasAvroSchema` / `ToAvro` / `FromAvro` instances to be encoded/decoded to/from Avro.

--- a/src/Data/Avro/Deriving.hs
+++ b/src/Data/Avro/Deriving.hs
@@ -57,7 +57,7 @@ import           Data.Map                     (Map)
 import           Data.Maybe                   (fromMaybe)
 import           Data.Semigroup               ((<>))
 import qualified Data.Text                    as Text
-import           Data.Time                    (Day, DiffTime, UTCTime)
+import           Data.Time                    (Day, DiffTime, LocalTime, UTCTime)
 import           Data.UUID                    (UUID)
 import           Text.RawString.QQ            (r)
 
@@ -437,6 +437,7 @@ mkFieldTypeName :: NamespaceBehavior -> S.Schema -> Q TH.Type
 mkFieldTypeName namespaceBehavior = \case
   S.Null             -> [t| () |]
   S.Boolean          -> [t| Bool |]
+
   S.Long (Just (DecimalL (Decimal p s)))
                      -> [t| Decimal $(litT $ numTyLit p) $(litT $ numTyLit s) |]
   S.Long (Just TimeMicros)
@@ -445,7 +446,12 @@ mkFieldTypeName namespaceBehavior = \case
                      -> [t| UTCTime |]
   S.Long (Just TimestampMillis)
                      -> [t| UTCTime |]
-  S.Long _           -> [t| Int64 |]
+  S.Long (Just LocalTimestampMillis)
+                     -> [t| LocalTime |]
+  S.Long (Just LocalTimestampMicros)
+                     -> [t| LocalTime |]
+  S.Long Nothing     -> [t| Int64 |]
+
   S.Int (Just Date)  -> [t| Day |]
   S.Int (Just TimeMillis)
                      -> [t| DiffTime |]

--- a/src/Data/Avro/Encoding/ToAvro.hs
+++ b/src/Data/Avro/Encoding/ToAvro.hs
@@ -157,11 +157,20 @@ instance ToAvro Time.DiffTime where
   toAvro s@(S.Long (Just S.TimestampMicros)) = toAvro @Int64 s . fromIntegral . diffTimeToMicros
   toAvro s@(S.Long (Just S.TimestampMillis)) = toAvro @Int64 s . fromIntegral . diffTimeToMillis
   toAvro s@(S.Int  (Just S.TimeMillis))      = toAvro @Int32 s . fromIntegral . diffTimeToMillis
-  toAvro s                                   = error ("Unble to decode DiffTime from " <> show s)
+  toAvro s                                   = error ("Unble to encode DiffTime as " <> show s)
 
 instance ToAvro Time.UTCTime where
   toAvro s@(S.Long (Just S.TimestampMicros)) = toAvro @Int64 s . fromIntegral . utcTimeToMicros
   toAvro s@(S.Long (Just S.TimestampMillis)) = toAvro @Int64 s . fromIntegral . utcTimeToMillis
+  toAvro s                                   = error ("Unable to encode UTCTime as " <> show s)
+
+instance ToAvro Time.LocalTime where
+  toAvro s@(S.Long (Just S.LocalTimestampMicros)) =
+    toAvro @Int64 s . fromIntegral . localTimeToMicros
+  toAvro s@(S.Long (Just S.LocalTimestampMillis)) =
+    toAvro @Int64 s . fromIntegral . localTimeToMillis
+  toAvro s =
+    error ("Unable to encode LocalTime as " <> show s)
 
 instance ToAvro B.ByteString where
   toAvro s bs = case s of

--- a/src/Data/Avro/HasAvroSchema.hs
+++ b/src/Data/Avro/HasAvroSchema.hs
@@ -104,6 +104,9 @@ instance HasAvroSchema Time.DiffTime where
 instance HasAvroSchema Time.UTCTime where
   schema = Tagged $ S.Long (Just TimestampMicros)
 
+instance HasAvroSchema Time.LocalTime where
+  schema = Tagged $ S.Long (Just LocalTimestampMicros)
+
 instance (HasAvroSchema a) => HasAvroSchema (Identity a) where
   schema = Tagged $ S.Union $ V.fromListN 1 [untag @a schema]
 

--- a/src/Data/Avro/Internal/Time.hs
+++ b/src/Data/Avro/Internal/Time.hs
@@ -50,3 +50,15 @@ microsToUTCTime x = addUTCTime (realToFrac $ picosecondsToDiffTime (x * 1000000)
 
 millisToUTCTime :: Integer -> UTCTime
 millisToUTCTime x = addUTCTime (realToFrac $ picosecondsToDiffTime (x * 1000000000)) epoch
+
+localTimeToMicros :: LocalTime -> Integer
+localTimeToMicros = utcTimeToMicros . localTimeToUTC utc
+
+localTimeToMillis :: LocalTime -> Integer
+localTimeToMillis = utcTimeToMillis . localTimeToUTC utc
+
+microsToLocalTime :: Integer -> LocalTime
+microsToLocalTime = utcToLocalTime utc . microsToUTCTime
+
+millisToLocalTime :: Integer -> LocalTime
+millisToLocalTime = utcToLocalTime utc . millisToUTCTime

--- a/test/Avro/Data/Logical.hs
+++ b/test/Avro/Data/Logical.hs
@@ -15,7 +15,7 @@
 module Avro.Data.Logical
 where
 
-import Data.Avro.Internal.Time (microsToDiffTime, microsToUTCTime, millisToDiffTime, millisToUTCTime)
+import Data.Avro.Internal.Time (microsToDiffTime, microsToLocalTime, microsToUTCTime, millisToDiffTime, millisToLocalTime, millisToUTCTime)
 
 import Data.Avro.Deriving (deriveAvroFromByteString, r)
 
@@ -59,7 +59,23 @@ deriveAvroFromByteString [r|
           "logicalType": "time-micros",
           "type": "long"
         }
-    }
+    },
+    {
+      "name": "localTimestampMillis",
+      "type":
+        {
+          "logicalType": "local-timestamp-millis",
+          "type": "long"
+        }
+     },
+     {
+      "name": "localTimestampMicros",
+      "type":
+        {
+          "logicalType": "local-timestamp-micros",
+          "type": "long"
+        }
+     }
   ]
 }
 |]
@@ -70,3 +86,5 @@ logicalGen = Logical
   <*> (microsToUTCTime  . toInteger <$> Gen.int64 (Range.linear 0 maxBound))
   <*> (millisToDiffTime . toInteger <$> Gen.int32 (Range.linear 0 maxBound))
   <*> (microsToDiffTime . toInteger <$> Gen.int64 (Range.linear 0 maxBound))
+  <*> (millisToLocalTime . toInteger <$> Gen.int64 (Range.linear 0 maxBound))
+  <*> (microsToLocalTime . toInteger <$> Gen.int64 (Range.linear 0 maxBound))

--- a/test/Avro/Gen/Schema.hs
+++ b/test/Avro/Gen/Schema.hs
@@ -27,4 +27,6 @@ int = do
 long :: MonadGen m => m Schema
 long = do
   dec <- decimalGen
-  Long <$> Gen.maybe (Gen.element [DecimalL dec, TimeMicros, TimestampMillis, TimestampMicros])
+  Long <$> Gen.maybe (Gen.element
+    [DecimalL dec, TimeMicros, TimestampMillis,
+     TimestampMicros, LocalTimestampMillis, LocalTimestampMicros])


### PR DESCRIPTION
Added the two remaining logical types from [the Avro specification][1]:

  * `local-timestamp-millis`
  * `local-timestamp-micros`

The encoding for these types is the same as `timestamp-millis` and `timestamp-micros` respectively, but they should be interpreted as *local* timestamps rather than UTC. This corresponds to the [`LocalTime`][2] type from the Haskell [time][3] package.

I also wrote Haddock documentation for all of the logical types supported by this package.

[1]: https://avro.apache.org/docs/current/spec.html#Logical+Types

[2]: https://hackage.haskell.org/package/time-1.13/docs/Data-Time-LocalTime.html#t:LocalTime

[3]: https://hackage.haskell.org/package/time