### PR TITLE
Add JSON serialization and deserialization support for schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ When working with `FromAvro` directly it is important to understand the differen
 
 `Schema` (as in the example above) is just a regular data schema for an Avro type.
 
-`ReadSchema` is a similar type, but it is capable of captuting and resolving differences between "_writer_ schema" and "_reader_ schema". See [Specification](https://avro.apache.org/docs/current/spec.html#Schema+Resolution) to learn more about schema resolution and de-conflicting.
+`ReadSchema` is a similar type, but it is capable of capturing and resolving differences between "_writer_ schema" and "_reader_ schema". See [Specification](https://avro.apache.org/docs/current/spec.html#Schema+Resolution) to learn more about schema resolution and de-conflicting.
 
 `FromAvro` class requires `ReaderSchema` because with Avro it is possible to read data with a different schema compared to the schema that was used for writing this data.
 

--- a/src/Data/Avro/EitherN.hs
+++ b/src/Data/Avro/EitherN.hs
@@ -443,6 +443,7 @@ instance (FromAvro a, FromAvro b, FromAvro c) => FromAvro (Either3 a b c) where
   fromAvro (AV.Union _ 1 b) = E3_2 <$> fromAvro b
   fromAvro (AV.Union _ 2 c) = E3_3 <$> fromAvro c
   fromAvro (AV.Union _ n _) = Left ("Unable to decode Either3 from a position #" <> show n)
+  fromAvro _                = Left "Unable to decode Either3 from a non-union"
 
 instance (FromAvro a, FromAvro b, FromAvro c, FromAvro d) => FromAvro (Either4 a b c d) where
   fromAvro (AV.Union _ 0 a) = E4_1 <$> fromAvro a
@@ -450,6 +451,7 @@ instance (FromAvro a, FromAvro b, FromAvro c, FromAvro d) => FromAvro (Either4 a
   fromAvro (AV.Union _ 2 c) = E4_3 <$> fromAvro c
   fromAvro (AV.Union _ 3 d) = E4_4 <$> fromAvro d
   fromAvro (AV.Union _ n _) = Left ("Unable to decode Either4 from a position #" <> show n)
+  fromAvro _                = Left "Unable to decode Either4 from a non-union"
 
 instance (FromAvro a, FromAvro b, FromAvro c, FromAvro d, FromAvro e) => FromAvro (Either5 a b c d e) where
   fromAvro (AV.Union _ 0 a) = E5_1 <$> fromAvro a
@@ -458,6 +460,7 @@ instance (FromAvro a, FromAvro b, FromAvro c, FromAvro d, FromAvro e) => FromAvr
   fromAvro (AV.Union _ 3 d) = E5_4 <$> fromAvro d
   fromAvro (AV.Union _ 4 e) = E5_5 <$> fromAvro e
   fromAvro (AV.Union _ n _) = Left ("Unable to decode Either5 from a position #" <> show n)
+  fromAvro _                = Left "Unable to decode Either5 from a non-union"
 
 instance (FromAvro a, FromAvro b, FromAvro c, FromAvro d, FromAvro e, FromAvro f) => FromAvro (Either6 a b c d e f) where
   fromAvro (AV.Union _ 0 a) = E6_1 <$> fromAvro a
@@ -467,6 +470,7 @@ instance (FromAvro a, FromAvro b, FromAvro c, FromAvro d, FromAvro e, FromAvro f
   fromAvro (AV.Union _ 4 e) = E6_5 <$> fromAvro e
   fromAvro (AV.Union _ 5 f) = E6_6 <$> fromAvro f
   fromAvro (AV.Union _ n _) = Left ("Unable to decode Either6 from a position #" <> show n)
+  fromAvro _                = Left "Unable to decode Either6 from a non-union"
 
 instance (FromAvro a, FromAvro b, FromAvro c, FromAvro d, FromAvro e, FromAvro f, FromAvro g) => FromAvro (Either7 a b c d e f g) where
   fromAvro (AV.Union _ 0 a) = E7_1 <$> fromAvro a
@@ -477,6 +481,7 @@ instance (FromAvro a, FromAvro b, FromAvro c, FromAvro d, FromAvro e, FromAvro f
   fromAvro (AV.Union _ 5 f) = E7_6 <$> fromAvro f
   fromAvro (AV.Union _ 6 g) = E7_7 <$> fromAvro g
   fromAvro (AV.Union _ n _) = Left ("Unable to decode Either7 from a position #" <> show n)
+  fromAvro _                = Left "Unable to decode Either7 from a non-union"
 
 instance (FromAvro a, FromAvro b, FromAvro c, FromAvro d, FromAvro e, FromAvro f, FromAvro g, FromAvro h) => FromAvro (Either8 a b c d e f g h) where
   fromAvro (AV.Union _ 0 a) = E8_1 <$> fromAvro a
@@ -488,6 +493,7 @@ instance (FromAvro a, FromAvro b, FromAvro c, FromAvro d, FromAvro e, FromAvro f
   fromAvro (AV.Union _ 6 g) = E8_7 <$> fromAvro g
   fromAvro (AV.Union _ 7 h) = E8_8 <$> fromAvro h
   fromAvro (AV.Union _ n _) = Left ("Unable to decode Either8 from a position #" <> show n)
+  fromAvro _                = Left "Unable to decode Either8 from a non-union"
 
 instance (FromAvro a, FromAvro b, FromAvro c, FromAvro d, FromAvro e, FromAvro f, FromAvro g, FromAvro h, FromAvro i) => FromAvro (Either9 a b c d e f g h i) where
   fromAvro (AV.Union _ 0 a) = E9_1 <$> fromAvro a
@@ -500,6 +506,7 @@ instance (FromAvro a, FromAvro b, FromAvro c, FromAvro d, FromAvro e, FromAvro f
   fromAvro (AV.Union _ 7 h) = E9_8 <$> fromAvro h
   fromAvro (AV.Union _ 8 i) = E9_9 <$> fromAvro i
   fromAvro (AV.Union _ n _) = Left ("Unable to decode Either9 from a position #" <> show n)
+  fromAvro _                = Left "Unable to decode Either9 from a non-union"
 
 instance (FromAvro a, FromAvro b, FromAvro c, FromAvro d, FromAvro e, FromAvro f, FromAvro g, FromAvro h, FromAvro i, FromAvro j) => FromAvro (Either10 a b c d e f g h i j) where
   fromAvro (AV.Union _ 0 a) = E10_1  <$> fromAvro a
@@ -513,6 +520,7 @@ instance (FromAvro a, FromAvro b, FromAvro c, FromAvro d, FromAvro e, FromAvro f
   fromAvro (AV.Union _ 8 i) = E10_9  <$> fromAvro i
   fromAvro (AV.Union _ 9 j) = E10_10 <$> fromAvro j
   fromAvro (AV.Union _ n _) = Left ("Unable to decode Either10 from a position #" <> show n)
+  fromAvro _                = Left "Unable to decode Either10 from a non-union"
 
 putIndexedValue :: ToAvro a => Int -> V.Vector Schema -> a -> Builder
 putIndexedValue i opts x = putI i <> toAvro (V.unsafeIndex opts i) x

--- a/src/Data/Avro/Encoding/FromAvro.hs
+++ b/src/Data/Avro/Encoding/FromAvro.hs
@@ -8,6 +8,7 @@ module Data.Avro.Encoding.FromAvro
   -- ** For internal use
 , Value(..)
 , getValue
+, convertValue
 )
 where
 

--- a/src/Data/Avro/Encoding/ToAvro.hs
+++ b/src/Data/Avro/Encoding/ToAvro.hs
@@ -234,7 +234,7 @@ instance ToAvro a => ToAvro (Map.Map Text a) where
   toAvro (S.Map s) hm =
     if Map.null hm then long0 else putI (F.length hm) <> foldMap putKV (Map.toList hm) <> long0
     where putKV (k,v) = toAvro S.String' k <> toAvro s v
-  toAvro s _         = error ("Unable to encode HashMap as: " <> show s)
+  toAvro s _         = error ("Unable to encode Map as: " <> show s)
 
 instance ToAvro a => ToAvro (HashMap Text a) where
   toAvro (S.Map s) hm =

--- a/src/Data/Avro/Internal/Time.hs
+++ b/src/Data/Avro/Internal/Time.hs
@@ -3,10 +3,8 @@ module Data.Avro.Internal.Time where
 
 -- Utility functions to work with times
 
-import Data.Fixed            (Fixed (..))
 import Data.Maybe            (fromJust)
 import Data.Time
-import Data.Time.Clock
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 #if MIN_VERSION_time(1,9,0)
 import Data.Time.Format.Internal

--- a/src/Data/Avro/JSON.hs
+++ b/src/Data/Avro/JSON.hs
@@ -1,5 +1,7 @@
+{-# LANGUAGE FlexibleInstances   #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
 -- | Avro supports a JSON representation of Avro objects alongside the
 -- Avro binary format. An Avro schema can be used to generate and
 -- validate JSON representations of Avro objects.
@@ -59,22 +61,38 @@
 -- @
 module Data.Avro.JSON where
 
+import           Control.Monad.Identity       (Identity (..))
 import qualified Data.Aeson           as Aeson
 import qualified Data.Aeson.Key       as K
 import qualified Data.Aeson.KeyMap    as KM
-import           Data.ByteString.Lazy (ByteString)
+import qualified Data.Array           as Ar
+import qualified Data.ByteString.Lazy as BL
+import qualified Data.ByteString      as BS
 import qualified Data.Foldable        as Foldable
 import           Data.HashMap.Strict  ((!))
 import qualified Data.HashMap.Strict  as HashMap
 import           Data.List.NonEmpty   (NonEmpty (..))
 import qualified Data.List.NonEmpty   as NE
+import qualified Data.Map             as Map
+import           Data.Maybe           (fromJust)
 import           Data.Tagged
 import qualified Data.Text            as Text
+import qualified Data.Text.Encoding   as Text
+import qualified Data.Text.Lazy       as LazyText
+import qualified Data.Time            as Time
 
 import qualified Data.Avro.HasAvroSchema as Schema
-import           Data.Avro.Schema.Schema (DefaultValue (..), Result (..), Schema, parseAvroJSON)
-import qualified Data.Avro.Schema.Schema as Schema
-import qualified Data.Vector             as V
+import           Data.Avro.EitherN
+import           Data.Avro.Internal.Time
+import           Data.Avro.Schema.Decimal as D
+import           Data.Avro.Schema.Schema  (DefaultValue (..), Result (..), Schema, parseAvroJSON)
+import qualified Data.Avro.Schema.Schema  as Schema
+import qualified Data.Vector              as V
+import qualified Data.Vector.Unboxed      as U
+import           Data.Int
+import           Data.Word
+import qualified Data.UUID                as UUID
+import           GHC.TypeLits
 
 decodeAvroJSON :: Schema -> Aeson.Value -> Result DefaultValue
 decodeAvroJSON schema json =
@@ -119,15 +137,333 @@ decodeAvroJSON schema json =
     isBuiltIn name = name `elem` [ "null", "boolean", "int", "long", "float"
                                  , "double", "bytes", "string", "array", "map" ]
 
--- -- | Convert a 'Aeson.Value' into a type that has an Avro schema. The
--- -- schema is used to validate the JSON and will return an 'Error' if
--- -- the JSON object is not encoded correctly or does not match the schema.
--- fromJSON :: forall a. (FromAvro a) => Aeson.Value -> Result a
--- fromJSON json = do
---   value <- decodeAvroJSON schema json
---   fromAvro value
---   where
---     schema = untag (Schema.schema :: Tagged a Schema)
+class ToAvroJSON a where
+  -- | Convert an object with an Avro schema to JSON using that schema.
+  --
+  -- We always need the schema to /encode/ to JSON because representing
+  -- unions requires using the names of named types.
+  toAvroJSON :: Schema -> a -> Aeson.Value
+  toAvroEncoding :: Schema -> a -> Aeson.Encoding
+  toAvroEncoding s = Aeson.toEncoding . toAvroJSON s
+
+instance ToAvroJSON Int where
+  -- It might seem surprising that we use fromIntegral here, but it's
+  -- used to ensure that overflow is handled correctly.
+  toAvroJSON (Schema.Long _) i = Aeson.toJSON @Int64 (fromIntegral i)
+  toAvroJSON (Schema.Int _) i  = Aeson.toJSON @Int32 (fromIntegral i)
+  toAvroJSON s _               = error ("Unable to encode Int as: " <> show s)
+  {-# INLINE toAvroJSON #-}
+
+instance ToAvroJSON Int32 where
+  toAvroJSON (Schema.Long _) i = Aeson.toJSON @Int64 (fromIntegral i)
+  toAvroJSON (Schema.Int _) i  = Aeson.toJSON @Int32 i
+  toAvroJSON Schema.Double i   = toAvroJSON @Double Schema.Double (fromIntegral i)
+  toAvroJSON Schema.Float i    = toAvroJSON @Float Schema.Float (fromIntegral i)
+  toAvroJSON s _               = error ("Unable to encode Int32 as: " <> show s)
+  {-# INLINE toAvroJSON #-}
+
+instance ToAvroJSON Int64 where
+  toAvroJSON (Schema.Long _) i = Aeson.toJSON i
+  toAvroJSON Schema.Double i   = toAvroJSON @Double Schema.Double (fromIntegral i)
+  toAvroJSON Schema.Float i    = toAvroJSON @Float Schema.Float (fromIntegral i)
+  toAvroJSON s _               = error ("Unable to encode Int64 as: " <> show s)
+  {-# INLINE toAvroJSON #-}
+
+instance ToAvroJSON Word8 where
+  toAvroJSON (Schema.Int _) i  = Aeson.toJSON @Word8 i
+  toAvroJSON (Schema.Long _) i = Aeson.toJSON @Word64 (fromIntegral i)
+  toAvroJSON Schema.Double i   = toAvroJSON @Double Schema.Double (fromIntegral i)
+  toAvroJSON Schema.Float i    = toAvroJSON @Float Schema.Float (fromIntegral i)
+  toAvroJSON s _               = error ("Unable to encode Word8 as: " <> show s)
+  {-# INLINE toAvroJSON #-}
+
+instance ToAvroJSON Word16 where
+  toAvroJSON (Schema.Int _) i  = Aeson.toJSON @Word16 i
+  toAvroJSON (Schema.Long _) i = Aeson.toJSON @Word64 (fromIntegral i)
+  toAvroJSON Schema.Double i   = toAvroJSON @Double Schema.Double (fromIntegral i)
+  toAvroJSON Schema.Float i    = toAvroJSON @Float Schema.Float (fromIntegral i)
+  toAvroJSON s _               = error ("Unable to encode Word16 as: " <> show s)
+  {-# INLINE toAvroJSON #-}
+
+instance ToAvroJSON Word32 where
+  toAvroJSON (Schema.Int _) i  = Aeson.toJSON @Word32 i
+  toAvroJSON (Schema.Long _) i = Aeson.toJSON @Word64 (fromIntegral i)
+  toAvroJSON Schema.Double i   = toAvroJSON @Double Schema.Double (fromIntegral i)
+  toAvroJSON Schema.Float i    = toAvroJSON @Float Schema.Float (fromIntegral i)
+  toAvroJSON s _               = error ("Unable to encode Word32 as: " <> show s)
+  {-# INLINE toAvroJSON #-}
+
+instance ToAvroJSON Word64 where
+  toAvroJSON (Schema.Long _) i = Aeson.toJSON @Word64 i
+  toAvroJSON Schema.Double i   = toAvroJSON @Double Schema.Double (fromIntegral i)
+  toAvroJSON s _               = error ("Unable to encode Word64 as: " <> show s)
+  {-# INLINE toAvroJSON #-}
+
+instance ToAvroJSON Double where
+  toAvroJSON Schema.Double i = Aeson.toJSON @Double i
+  toAvroJSON s _             = error ("Unable to encode Double as: " <> show s)
+  {-# INLINE toAvroJSON #-}
+
+instance ToAvroJSON Float where
+  toAvroJSON Schema.Float i  = Aeson.toJSON @Float i
+  toAvroJSON Schema.Double i = Aeson.toJSON @Double $ realToFrac i
+  toAvroJSON s _             = error ("Unable to encode Float as: " <> show s)
+  {-# INLINE toAvroJSON #-}
+
+instance ToAvroJSON () where
+  toAvroJSON Schema.Null () = Aeson.Null
+  toAvroJSON s ()           = error ("Unable to encode () as: " <> show s)
+  {-# INLINE toAvroJSON #-}
+
+
+instance ToAvroJSON Bool where
+  toAvroJSON Schema.Boolean v = Aeson.toJSON v
+  toAvroJSON s _              = error ("Unable to encode Bool as: " <> show s)
+  {-# INLINE toAvroJSON #-}
+  toAvroEncoding Schema.Boolean v = Aeson.toEncoding v
+  toAvroEncoding s _              = error ("Unable to encode Bool as: " <> show s)
+  {-# INLINE toAvroEncoding #-}
+
+instance ToAvroJSON Text.Text where
+  toAvroJSON (Schema.Bytes _)  v = Aeson.toJSON $ Schema.serializeBytes $ Text.encodeUtf8 v
+  toAvroJSON (Schema.String _) v = Aeson.toJSON v
+  toAvroJSON s _                 = error ("Unable to encode Text as: " <> show s)
+  {-# INLINE toAvroJSON #-}
+
+instance ToAvroJSON LazyText.Text where
+  toAvroJSON (Schema.Bytes _)  v = Aeson.toJSON $ Schema.serializeBytes $ Text.encodeUtf8 $ LazyText.toStrict v
+  toAvroJSON (Schema.String _) v = Aeson.toJSON v
+  toAvroJSON s _                 = error ("Unable to encode Text as: " <> show s)
+  {-# INLINE toAvroJSON #-}
+
+instance ToAvroJSON BS.ByteString where
+  toAvroJSON s bs = case s of
+    (Schema.Bytes _)                         -> Aeson.toJSON $ Schema.serializeBytes bs
+    (Schema.String _)                        -> Aeson.toJSON $ Text.decodeUtf8 bs
+    Schema.Fixed _ _ l _ | l == BS.length bs -> Aeson.toJSON $ Schema.serializeBytes bs
+    Schema.Fixed _ _ l _                     -> error ("Unable to encode ByteString as Fixed(" <> show l <> ") because its length is " <> show (BS.length bs))
+    _                                        -> error ("Unable to encode ByteString as: " <> show s)
+  {-# INLINE toAvroJSON #-}
+
+instance ToAvroJSON BL.ByteString where
+  toAvroJSON s bs = toAvroJSON s (BL.toStrict bs)
+  {-# INLINE toAvroJSON #-}
+
+instance ToAvroJSON Time.UTCTime where
+  toAvroJSON s@(Schema.Long (Just Schema.TimestampMicros)) = toAvroJSON @Int64 s . fromIntegral . utcTimeToMicros
+  toAvroJSON s@(Schema.Long (Just Schema.TimestampMillis)) = toAvroJSON @Int64 s . fromIntegral . utcTimeToMillis
+  toAvroJSON s                                             = error ("Unable to encode UTCTime as " <> show s)
+
+instance ToAvroJSON Time.LocalTime where
+  toAvroJSON s@(Schema.Long (Just Schema.LocalTimestampMicros)) =
+    toAvroJSON @Int64 s . fromIntegral . localTimeToMicros
+  toAvroJSON s@(Schema.Long (Just Schema.LocalTimestampMillis)) =
+    toAvroJSON @Int64 s . fromIntegral . localTimeToMillis
+  toAvroJSON s =
+    error ("Unable to encode LocalTime as " <> show s)
+
+instance ToAvroJSON Time.DiffTime where
+  toAvroJSON s@(Schema.Long (Just Schema.TimeMicros))      = toAvroJSON @Int64 s . fromIntegral . diffTimeToMicros
+  toAvroJSON s@(Schema.Long (Just Schema.TimestampMicros)) = toAvroJSON @Int64 s . fromIntegral . diffTimeToMicros
+  toAvroJSON s@(Schema.Long (Just Schema.TimestampMillis)) = toAvroJSON @Int64 s . fromIntegral . diffTimeToMillis
+  toAvroJSON s@(Schema.Int  (Just Schema.TimeMillis))      = toAvroJSON @Int32 s . fromIntegral . diffTimeToMillis
+  toAvroJSON s                                   = error ("Unble to encode DiffTime as " <> show s)
+
+instance ToAvroJSON Time.Day where
+  toAvroJSON s = toAvroJSON @Int32 s . fromIntegral . daysSinceEpoch
+  {-# INLINE toAvroJSON #-}
+
+instance ToAvroJSON UUID.UUID where
+  toAvroJSON s = toAvroJSON s . UUID.toText
+  {-# INLINE toAvroJSON #-}
+
+instance ToAvroJSON a => ToAvroJSON [a] where
+  toAvroJSON (Schema.Array s) as = Aeson.toJSON $ fmap (toAvroJSON s) as
+  toAvroJSON s _                 = error ("Unable to encode Haskell list as: " <> show s)
+
+instance (ToAvroJSON a) => ToAvroJSON (Identity a) where
+  toAvroJSON (Schema.Union opts) e@(Identity a) =
+    if V.length opts == 1
+      then toAvroUnionJSON (V.unsafeIndex opts 0) a
+      else error ("Unable to encode Identity as a single-value union: " <> show opts)
+  toAvroJSON s _ = error ("Unable to encode Identity value as " <> show s)
+
+instance ToAvroJSON a => ToAvroJSON (Maybe a) where
+  toAvroJSON (Schema.Union opts) v =
+    case Foldable.toList opts of
+      [Schema.Null, s] -> maybe (toAvroJSON Schema.Null ()) (toAvroJSON s) v
+      [s, Schema.Null] -> maybe (toAvroJSON Schema.Null ()) (toAvroJSON s) v
+      wrongOpts   -> error ("Unable to encode Maybe as " <> show wrongOpts)
+  toAvroJSON s _ = error ("Unable to encode Maybe as " <> show s)
+
+instance (U.Unbox a, ToAvroJSON a) => ToAvroJSON (U.Vector a) where
+  toAvroJSON (Schema.Array s) as = Aeson.toJSON @(V.Vector Aeson.Value) $ fmap (toAvroJSON s) $ U.convert as
+  toAvroJSON s _                 = error ("Unable to encode Vector list as: " <> show s)
+
+instance (ToAvroJSON a) => ToAvroJSON (V.Vector a) where
+  toAvroJSON (Schema.Array s) as = Aeson.toJSON $ fmap (toAvroJSON s) as
+  toAvroJSON s _                 = error ("Unable to encode Vector list as: " <> show s)
+
+instance (ToAvroJSON a, ToAvroJSON b) => ToAvroJSON (Either a b) where
+  toAvroJSON (Schema.Union opts) v =
+    if V.length opts == 2
+      then case v of
+        Left a  -> toAvroUnionJSON (V.unsafeIndex opts 0) a
+        Right b -> toAvroUnionJSON (V.unsafeIndex opts 1) b
+      else error ("Unable to encode Either as " <> show opts)
+  toAvroJSON s _ = error ("Unable to encode Either as " <> show s)
+
+instance ToAvroJSON a => ToAvroJSON (Map.Map Text.Text a) where
+  toAvroJSON (Schema.Map s) m = Aeson.toJSON $ fmap (toAvroJSON s) m
+  toAvroJSON s _                   = error ("Unable to encode Map as: " <> show s)
+
+instance ToAvroJSON a => ToAvroJSON (HashMap.HashMap Text.Text a) where
+  toAvroJSON (Schema.Map s) hm = Aeson.toJSON $ fmap (toAvroJSON s) hm
+  toAvroJSON s _               = error ("Unable to encode HashMap as: " <> show s)
+
+instance (Ar.Ix i, ToAvroJSON a) => ToAvroJSON (Ar.Array i a) where
+  toAvroJSON (Schema.Array s) a = Aeson.toJSON $ fmap (toAvroJSON s) $ Foldable.toList a
+  toAvroJSON s _                = error ("Unable to encode indexed Array list as: " <> show s)
+
+-- TODO, I don't know if this is the right way to do this.
+instance (KnownNat p, KnownNat s) => ToAvroJSON (Decimal p s) where
+  toAvroJSON s = toAvroJSON @Int64 s . fromIntegral . fromJust . D.underlyingValue
+
+instance (ToAvroJSON a, ToAvroJSON b, ToAvroJSON c) => ToAvroJSON (Either3 a b c) where
+  toAvroJSON (Schema.Union opts) v =
+    if V.length opts == 3
+      then case v of
+        E3_1 x -> toAvroUnionJSON (V.unsafeIndex opts 0) x
+        E3_2 x -> toAvroUnionJSON (V.unsafeIndex opts 1) x
+        E3_3 x -> toAvroUnionJSON (V.unsafeIndex opts 2) x
+      else error ("Unable to encode Either3 as " <> show opts)
+  toAvroJSON s _ = error ("Unable to encode Either3 as " <> show s)
+
+instance (ToAvroJSON a, ToAvroJSON b, ToAvroJSON c, ToAvroJSON d) => ToAvroJSON (Either4 a b c d) where
+  toAvroJSON (Schema.Union opts) v =
+    if V.length opts == 4
+      then case v of
+        E4_1 x -> toAvroUnionJSON (V.unsafeIndex opts 0) x
+        E4_2 x -> toAvroUnionJSON (V.unsafeIndex opts 1) x
+        E4_3 x -> toAvroUnionJSON (V.unsafeIndex opts 2) x
+        E4_4 x -> toAvroUnionJSON (V.unsafeIndex opts 3) x
+      else error ("Unable to encode Either4 as " <> show opts)
+  toAvroJSON s _ = error ("Unable to encode Either4 as " <> show s)
+
+instance (ToAvroJSON a, ToAvroJSON b, ToAvroJSON c, ToAvroJSON d, ToAvroJSON e) => ToAvroJSON (Either5 a b c d e) where
+  toAvroJSON (Schema.Union opts) v =
+    if V.length opts == 5
+      then case v of
+        E5_1 x -> toAvroUnionJSON (V.unsafeIndex opts 0) x
+        E5_2 x -> toAvroUnionJSON (V.unsafeIndex opts 1) x
+        E5_3 x -> toAvroUnionJSON (V.unsafeIndex opts 2) x
+        E5_4 x -> toAvroUnionJSON (V.unsafeIndex opts 3) x
+        E5_5 x -> toAvroUnionJSON (V.unsafeIndex opts 4) x
+      else error ("Unable to encode Either5 as " <> show opts)
+  toAvroJSON s _ = error ("Unable to encode Either5 as " <> show s)
+
+instance (ToAvroJSON a, ToAvroJSON b, ToAvroJSON c, ToAvroJSON d, ToAvroJSON e, ToAvroJSON f) => ToAvroJSON (Either6 a b c d e f) where
+  toAvroJSON (Schema.Union opts) v =
+    if V.length opts == 6
+      then case v of
+        E6_1 x -> toAvroUnionJSON (V.unsafeIndex opts 0) x
+        E6_2 x -> toAvroUnionJSON (V.unsafeIndex opts 1) x
+        E6_3 x -> toAvroUnionJSON (V.unsafeIndex opts 2) x
+        E6_4 x -> toAvroUnionJSON (V.unsafeIndex opts 3) x
+        E6_5 x -> toAvroUnionJSON (V.unsafeIndex opts 4) x
+        E6_6 x -> toAvroUnionJSON (V.unsafeIndex opts 5) x
+      else error ("Unable to encode Either6 as " <> show opts)
+  toAvroJSON s _ = error ("Unable to encode Either6 as " <> show s)
+
+instance (ToAvroJSON a, ToAvroJSON b, ToAvroJSON c, ToAvroJSON d, ToAvroJSON e, ToAvroJSON f, ToAvroJSON g) => ToAvroJSON (Either7 a b c d e f g) where
+  toAvroJSON (Schema.Union opts) v =
+    if V.length opts == 7
+      then case v of
+        E7_1 x -> toAvroUnionJSON (V.unsafeIndex opts 0) x
+        E7_2 x -> toAvroUnionJSON (V.unsafeIndex opts 1) x
+        E7_3 x -> toAvroUnionJSON (V.unsafeIndex opts 2) x
+        E7_4 x -> toAvroUnionJSON (V.unsafeIndex opts 3) x
+        E7_5 x -> toAvroUnionJSON (V.unsafeIndex opts 4) x
+        E7_6 x -> toAvroUnionJSON (V.unsafeIndex opts 5) x
+        E7_7 x -> toAvroUnionJSON (V.unsafeIndex opts 6) x
+      else error ("Unable to encode Either7 as " <> show opts)
+  toAvroJSON s _ = error ("Unable to encode Either7 as " <> show s)
+
+instance (ToAvroJSON a, ToAvroJSON b, ToAvroJSON c, ToAvroJSON d, ToAvroJSON e, ToAvroJSON f, ToAvroJSON g, ToAvroJSON h) => ToAvroJSON (Either8 a b c d e f g h) where
+  toAvroJSON (Schema.Union opts) v =
+    if V.length opts == 8
+      then case v of
+        E8_1 x -> toAvroUnionJSON (V.unsafeIndex opts 0) x
+        E8_2 x -> toAvroUnionJSON (V.unsafeIndex opts 1) x
+        E8_3 x -> toAvroUnionJSON (V.unsafeIndex opts 2) x
+        E8_4 x -> toAvroUnionJSON (V.unsafeIndex opts 3) x
+        E8_5 x -> toAvroUnionJSON (V.unsafeIndex opts 4) x
+        E8_6 x -> toAvroUnionJSON (V.unsafeIndex opts 5) x
+        E8_7 x -> toAvroUnionJSON (V.unsafeIndex opts 6) x
+        E8_8 x -> toAvroUnionJSON (V.unsafeIndex opts 7) x
+      else error ("Unable to encode Either8 as " <> show opts)
+  toAvroJSON s _ = error ("Unable to encode Either8 as " <> show s)
+
+instance (ToAvroJSON a, ToAvroJSON b, ToAvroJSON c, ToAvroJSON d, ToAvroJSON e, ToAvroJSON f, ToAvroJSON g, ToAvroJSON h, ToAvroJSON i) => ToAvroJSON (Either9 a b c d e f g h i) where
+  toAvroJSON (Schema.Union opts) v =
+    if V.length opts == 9
+      then case v of
+        E9_1 x -> toAvroUnionJSON (V.unsafeIndex opts 0) x
+        E9_2 x -> toAvroUnionJSON (V.unsafeIndex opts 1) x
+        E9_3 x -> toAvroUnionJSON (V.unsafeIndex opts 2) x
+        E9_4 x -> toAvroUnionJSON (V.unsafeIndex opts 3) x
+        E9_5 x -> toAvroUnionJSON (V.unsafeIndex opts 4) x
+        E9_6 x -> toAvroUnionJSON (V.unsafeIndex opts 5) x
+        E9_7 x -> toAvroUnionJSON (V.unsafeIndex opts 6) x
+        E9_8 x -> toAvroUnionJSON (V.unsafeIndex opts 7) x
+        E9_9 x -> toAvroUnionJSON (V.unsafeIndex opts 8) x
+      else error ("Unable to encode Either9 as " <> show opts)
+  toAvroJSON s _ = error ("Unable to encode Either9 as " <> show s)
+
+instance (ToAvroJSON a, ToAvroJSON b, ToAvroJSON c, ToAvroJSON d, ToAvroJSON e, ToAvroJSON f, ToAvroJSON g, ToAvroJSON h, ToAvroJSON i, ToAvroJSON j) => ToAvroJSON (Either10 a b c d e f g h i j) where
+  toAvroJSON (Schema.Union opts) v =
+    if V.length opts == 9
+      then case v of
+        E10_1 x -> toAvroUnionJSON (V.unsafeIndex opts 0) x
+        E10_2 x -> toAvroUnionJSON (V.unsafeIndex opts 1) x
+        E10_3 x -> toAvroUnionJSON (V.unsafeIndex opts 2) x
+        E10_4 x -> toAvroUnionJSON (V.unsafeIndex opts 3) x
+        E10_5 x -> toAvroUnionJSON (V.unsafeIndex opts 4) x
+        E10_6 x -> toAvroUnionJSON (V.unsafeIndex opts 5) x
+        E10_7 x -> toAvroUnionJSON (V.unsafeIndex opts 6) x
+        E10_8 x -> toAvroUnionJSON (V.unsafeIndex opts 7) x
+        E10_9 x -> toAvroUnionJSON (V.unsafeIndex opts 8) x
+        E10_10 x -> toAvroUnionJSON (V.unsafeIndex opts 9) x
+      else error ("Unable to encode Either10 as " <> show opts)
+  toAvroJSON s _ = error ("Unable to encode Either10 as " <> show s)
+
+toAvroUnionJSON :: ToAvroJSON a => Schema -> a -> Aeson.Value
+toAvroUnionJSON s x = case s of
+  Schema.Null -> toAvroJSON s x
+  -- TODO, not sure if this is supposed to use logical types, need to
+  -- compare with other language implementations
+  _ -> Aeson.toJSON $ HashMap.singleton (Schema.typeName s) (toAvroJSON s x)
+
+toJSON :: forall a. (Schema.HasAvroSchema a, ToAvroJSON a) => a -> Aeson.Value
+toJSON = toAvroJSON schema
+  where
+    schema = untag (Schema.schema :: Tagged a Schema)
+
+toEncoding :: forall a. (Schema.HasAvroSchema a, ToAvroJSON a) => a -> Aeson.Encoding
+toEncoding = toAvroEncoding schema
+  where
+    schema = untag (Schema.schema :: Tagged a Schema)
+
+class FromAvroJSON a where
+  -- | Convert a 'Aeson.Value' into a type that has an Avro schema. The
+  -- schema is used to validate the JSON and will return an 'Error' if
+  -- the JSON object is not encoded correctly or does not match the schema.
+  fromAvroJSON :: Schema -> Aeson.Value -> Result a
+
+fromJSON :: forall a. (Schema.HasAvroSchema a, FromAvroJSON a) => Aeson.Value -> Result a
+fromJSON = fromAvroJSON schema 
+  where
+    schema = untag (Schema.schema :: Tagged a Schema)
 
 -- -- | Parse a 'ByteString' as JSON and convert it to a type with an
 -- -- Avro schema. Will return 'Error' if the input is not valid JSON or
@@ -136,10 +472,3 @@ decodeAvroJSON schema json =
 -- parseJSON input = case Aeson.eitherDecode input of
 --   Left msg    -> Error msg
 --   Right value -> fromJSON value
-
--- -- | Convert an object with an Avro schema to JSON using that schema.
--- --
--- -- We always need the schema to /encode/ to JSON because representing
--- -- unions requires using the names of named types.
--- toJSON :: forall a. (ToAvro a) => a -> Aeson.Value
--- toJSON = Aeson.toJSON . toAvro

--- a/src/Data/Avro/Schema/Decimal.hs
+++ b/src/Data/Avro/Schema/Decimal.hs
@@ -6,10 +6,11 @@
 module Data.Avro.Schema.Decimal where
 
 import qualified Data.BigDecimal as D
+import           Data.Scientific as S
 import           Data.Proxy
 import           GHC.TypeLits
 
-newtype Decimal (p :: Nat) (s :: Nat)
+newtype Decimal (precision :: Nat) (scale :: Nat)
   = Decimal { unDecimal :: D.BigDecimal }
   deriving (Eq, Ord, Show, Read, Num, Fractional, Real)
 
@@ -31,3 +32,17 @@ underlyingValue (Decimal d)
     in if D.precision new > pp
           then Nothing
           else Just $ fromInteger $ D.getValue new
+
+clamp :: forall p s. (KnownNat p, KnownNat s) => Decimal p s -> Decimal p s
+clamp (Decimal d)
+  = let ss = natVal (Proxy :: Proxy s)
+        pp = natVal (Proxy :: Proxy p)
+        new = if ss > D.getScale d
+                 then D.BigDecimal (D.getValue d * 10 ^ (ss - D.getScale d)) ss
+                 else D.roundBD d (D.halfUp ss)
+    in Decimal new
+
+toScientific :: (KnownNat p, KnownNat s) => Decimal p s -> Scientific
+toScientific d 
+  = let (Decimal d') = clamp d
+    in S.scientific (D.getValue d') (negate $ fromIntegral $ D.getScale d')

--- a/src/Data/Avro/Schema/Deconflict.hs
+++ b/src/Data/Avro/Schema/Deconflict.hs
@@ -30,7 +30,12 @@ import Debug.Trace
 -- with the writer's schema into the form specified by the reader's schema.
 --
 -- Schema resolution rules are described by the specification: <https://avro.apache.org/docs/current/spec.html#Schema+Resolution>
-deconflict :: Schema -> Schema -> Either String ReadSchema
+deconflict 
+  :: Schema 
+  -- ^ The writer's schema.
+  -> Schema 
+  -- ^ The reader's schema.
+  -> Either String ReadSchema
 deconflict writerSchema readerSchema | writerSchema == readerSchema = pure (Read.fromSchema readerSchema)
 deconflict S.Null S.Null             = pure Read.Null
 deconflict S.Boolean S.Boolean       = pure Read.Boolean

--- a/src/Data/Avro/Schema/Schema.hs
+++ b/src/Data/Avro/Schema/Schema.hs
@@ -849,6 +849,7 @@ parseFieldDefault env schema value = parseAvroJSON defaultUnion env schema value
   where defaultUnion (Union ts) val = DUnion ts (V.head ts) <$> parseFieldDefault env (V.head ts) val
         defaultUnion _ _            = error "Impossible: not Union."
 
+-- TODO deprecate this function in favor of JSON module
 -- | Parse JSON-encoded avro data.
 parseAvroJSON :: (Schema -> A.Value -> Result DefaultValue)
                  -- ^ How to handle unions. The way unions are

--- a/src/Data/Avro/Schema/Schema.hs
+++ b/src/Data/Avro/Schema/Schema.hs
@@ -1055,11 +1055,10 @@ overlay input supplement = overlayType input
     overlayType  m@Map{..}        = m { values  = overlayType values }
     overlayType  r@Record{..}     = r { fields  = map overlayField fields }
     overlayType  u@Union{..}      = Union (fmap overlayType options)
-    overlayType  nt@(NamedType _) = rebind nt
+    overlayType  (NamedType tn)   = HashMap.lookupDefault (NamedType tn) tn bindings
     overlayType  other            = other
 
-    rebind (NamedType tn) = HashMap.lookupDefault (NamedType tn) tn bindings
-    bindings              = extractBindings supplement
+    bindings = extractBindings supplement
 
 -- | Extract the named inner type definition as its own schema.
 subdefinition :: Schema -> Text -> Maybe Schema

--- a/test/Avro/JSONSpec.hs
+++ b/test/Avro/JSONSpec.hs
@@ -1,7 +1,9 @@
 {-# LANGUAGE DeriveGeneric       #-}
 {-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE QuasiQuotes         #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell     #-}
+{-# LANGUAGE TypeApplications    #-}
 module Avro.JSONSpec where
 
 import Control.Monad (forM_)
@@ -10,14 +12,31 @@ import           Control.Monad.Identity (Identity (..))
 import qualified Data.Aeson             as Aeson
 import qualified Data.ByteString        as BS
 import qualified Data.ByteString.Lazy   as LBS
+import           Data.Either            (isRight)
+import           Data.Int
 import qualified Data.Map               as Map
+import qualified Data.HashMap.Strict    as HM
+import           Data.Tagged
+import qualified Data.Text              as T
+import qualified Data.Text.Encoding     as T
+import qualified Data.Text.Lazy          as TL
+import qualified Data.Text.Lazy.Encoding as TL
 
 import Data.Avro.Deriving
 import Data.Avro.EitherN
+import Data.Avro.Encoding.FromAvro
 import Data.Avro.JSON
+import Data.Avro.HasAvroSchema
+import Data.Avro.Schema.Deconflict (deconflict)
+import qualified Data.Avro.Schema.Schema as S
+import Data.Avro.Schema.ReadSchema
 
+import qualified Avro.Data.Deconflict.Read as Read
+import qualified Avro.Data.Deconflict.Write as Write
 import Avro.Data.Endpoint
 import Avro.Data.Enums
+import Avro.Data.FixedTypes
+import Avro.Data.Karma
 import Avro.Data.Reused
 import Avro.Data.Unions
 
@@ -34,10 +53,93 @@ import System.Environment (setEnv)
 {- HLINT ignore "Redundant do"        -}
 
 deriveAvro "test/data/unions-no-namespace.avsc"
+deriveAvro "test/data/maybe.avsc"
+
+roundtripGen :: (Monad m, Show a, Eq a, ToAvroJSON a, FromAvro a) => S.Schema -> Gen a -> PropertyT m ()
+roundtripGen sch gen = do
+  value <- forAll gen
+  tripping value (toAvroJSON sch) (fromJSON (fromSchema sch)) 
+
+roundtripGenKnownSchema :: (Monad m, Show a, Eq a, ToAvroJSON a, FromAvro a, HasAvroSchema a) => Gen a -> PropertyT m ()
+roundtripGenKnownSchema gen = do
+  value <- forAll gen
+  let sch = schemaOf value
+  tripping value (toAvroJSON sch) (fromJSON (fromSchema sch)) 
+
+
 
 spec :: Spec
 spec = describe "Avro.JSONSpec: JSON serialization/parsing" $ do
   it "should pass" $ require $ withTests 1 $ property success
+
+  describe "ToAvroJSON instances" $ do
+    specify "Int" $ do
+      let int = 1 :: Int
+      toAvroJSON (S.Long Nothing) int `shouldBe` Aeson.Number 1
+      toAvroJSON (S.Int Nothing) int `shouldBe` Aeson.Number 1
+    specify "Int32" $ do
+      let int = 1 :: Int32
+      toAvroJSON (S.Long Nothing) int `shouldBe` Aeson.Number 1
+      toAvroJSON (S.Int Nothing) int `shouldBe` Aeson.Number 1
+
+  describe "Schema evolution" $ do
+    it "can read values in older formats from new schemas" $ do
+      let writeSchema = unTagged $ schema @Write.Foo
+          readSchema = unTagged $ schema @Read.Foo
+          (Right deconflicted) = deconflict writeSchema readSchema
+      require $ property $ do
+        foo <- forAll Write.genFoo
+        let jsonAnnotation = TL.unpack $ TL.decodeUtf8 $ Aeson.encode $ toJSON foo
+        annotate jsonAnnotation
+        annotate $ show deconflicted
+        case  fromJSON @Read.Foo deconflicted (toJSON foo) of
+          Left err -> annotate err >> failure
+          Right _ -> success
+  describe "Roundtrip" $ do
+    it "Null roundtrip" $ require $ withTests 1 $ property $ do
+      roundtripGen S.Null (Gen.constant ())
+    it "Bool roundtrip" $ require $ withTests 2 $ property $ do
+      roundtripGen S.Boolean Gen.bool_
+    it "Int roundtrip" $ require $ property $ do
+      roundtripGen (S.Int Nothing) (Gen.int32 Range.linearBounded)
+    it "Long roundtrip" $ require $ property $ do
+      roundtripGen (S.Long Nothing) (Gen.int Range.linearBounded)
+      roundtripGen (S.Long Nothing) (Gen.int64 Range.linearBounded)
+    it "Float roundtrip" $ require $ property $ do
+      roundtripGen S.Float (Gen.float (Range.exponentialFloat (-500) 500))
+    it "Double roundtrip" $ require $ property $ do
+      roundtripGen S.Double (Gen.double (Range.exponentialFloat (-500) 500))
+    it "Bytes roundtrip" $ require $ property $ do
+      roundtripGen (S.Bytes Nothing) (Gen.bytes (Range.linear 0 100))
+    it "String roundtrip" $ require $ property $ do
+      roundtripGen (S.String Nothing) (Gen.text (Range.linear 0 100) Gen.unicodeAll)
+    it "Array roundtrip" $ require $ property $ do
+      roundtripGen (S.Array $ S.Long Nothing) (Gen.list (Range.linear 0 100) $ Gen.int Range.linearBounded)
+    it "Map roundtrip" $ require $ property $ do
+      let gen = do
+            items <- Gen.list 
+              (Range.linear 0 100) 
+              (do
+                k <- Gen.text (Range.linear 1 100) Gen.alphaNum 
+                v <- Gen.int Range.linearBounded
+                pure (k, v)
+              )
+            pure $ HM.fromList items
+      roundtripGen (S.Map $ S.Long Nothing) gen
+    -- TODO named types
+    -- TODO record types
+    describe "Record roundtrip" $ do
+      specify "Endpoint" $ require $ property $ roundtripGenKnownSchema endpointGen
+      specify "Blessing" $ require $ property $ roundtripGenKnownSchema blessingGen
+      specify "Curse" $ require $ property $ roundtripGenKnownSchema curseGen
+      specify "ReuseFixed" $ require $ property $ roundtripGenKnownSchema reuseFixedGen
+      specify "Unions" $ require $ property $ roundtripGenKnownSchema unionsGen
+
+    it "Enum roundtrip" $ require $ property $ do
+      roundtripGen (schemaOf EnumReasonBecause) (Gen.enumBounded :: Gen EnumReason)
+    -- TODO it "Union roundtrip"
+    it "Fixed roundtrip" $ require $ property $ do
+      roundtripGen (schemaOf $ FixedTag "wow") (fmap FixedTag $ Gen.bytes $ Range.singleton 3)
 
   -- it "should do roundtrip (enums)" $ require $ property $ do
   --   msg <- forAll enumWrapperGen


### PR DESCRIPTION
This is a first pass at adding support for JSON serialization / deserialization support. There was some older code for deserializing some a JSON input based on a `Schema`, but newer support for deconflicting and `ReadSchema`s made it not particularly usable.  Note: I haven't tested against other language's JSON serialization output, so at best this PR's tests only really prove a degree of internal consistency.

I think this addresses #159 