### PR TITLE
Consider aliases when deconflicting FreeUnion

### DIFF
--- a/src/Data/Avro/Schema/Deconflict.hs
+++ b/src/Data/Avro/Schema/Deconflict.hs
@@ -138,6 +138,7 @@ findField w rs =
 findTypeV :: Schema -> Vector Schema -> Maybe (Int, Schema)
 findTypeV schema schemas =
   let tn = typeName schema
-      allNames typ = typeName typ : map renderFullname (aliases typ)
-  in ((,) <$> id <*> V.unsafeIndex schemas) <$> 
+      allNames typ =
+        typeName typ : map renderFullname (typeAliases typ)
+  in ((,) <$> id <*> V.unsafeIndex schemas) <$>
         V.findIndex ((tn `elem`) . allNames) schemas

--- a/src/Data/Avro/Schema/Deconflict.hs
+++ b/src/Data/Avro/Schema/Deconflict.hs
@@ -138,4 +138,6 @@ findField w rs =
 findTypeV :: Schema -> Vector Schema -> Maybe (Int, Schema)
 findTypeV schema schemas =
   let tn = typeName schema
-  in ((,) <$> id <*> V.unsafeIndex schemas) <$> V.findIndex ((tn ==) . typeName) schemas
+      allNames typ = typeName typ : map renderFullname (aliases typ)
+  in ((,) <$> id <*> V.unsafeIndex schemas) <$> 
+        V.findIndex ((tn `elem`) . allNames) schemas

--- a/src/Data/Avro/Schema/Schema.hs
+++ b/src/Data/Avro/Schema/Schema.hs
@@ -37,6 +37,7 @@ module Data.Avro.Schema.Schema
   , validateSchema
   -- * Lower level utilities
   , typeName
+  , typeAliases
   , buildTypeEnvironment
   , extractBindings
 
@@ -495,6 +496,15 @@ typeName bt =
     _               -> renderFullname $ name bt
   where
     decimalName (Decimal prec sc) = "decimal(" <> T.pack (show prec) <> "," <> T.pack (show sc) <> ")"
+
+-- |Get the aliases of the type.
+typeAliases :: Schema -> [TypeName]
+typeAliases bt =
+  case bt of
+    Record { aliases } -> aliases
+    Enum { aliases} -> aliases
+    Fixed { aliases } -> aliases
+    _ -> []
 
 instance FromJSON Schema where
   parseJSON = parseSchemaJSON Nothing


### PR DESCRIPTION
This is failing CI because not every constructor of Schema has an `aliases` field. Fix incoming.