### PR TITLE
Consider aliases when deconflicting records

### DIFF
--- a/src/Data/Avro/Schema/Deconflict.hs
+++ b/src/Data/Avro/Schema/Deconflict.hs
@@ -76,7 +76,7 @@ deconflict w@S.Fixed {} r@S.Fixed {}
     }
 
 deconflict w@S.Record {} r@S.Record {}
-  | name w == name r = do
+  | name w == name r || name w `elem` aliases r = do
     fields' <- deconflictFields (fields w) (fields r)
     pure Read.Record
       { Read.name    = name r


### PR DESCRIPTION
This is another finding from our use of Avro at Scarf.

I think Enums and others need this treatment too. 