### PR TITLE
Fixup warnings, improve error messages

### DIFF
--- a/avro.cabal
+++ b/avro.cabal
@@ -90,6 +90,8 @@ common gauge                    { if arch(x86_64) || arch(i386) { build-depends:
 
 common config
   default-language:     Haskell2010
+  ghc-options:          -Wall
+
   if flag(dev)
     ghc-options:        -Wall -Werror
 

--- a/src/Data/Avro/Deriving/Lift.hs
+++ b/src/Data/Avro/Deriving/Lift.hs
@@ -7,12 +7,6 @@
 module Data.Avro.Deriving.Lift where
 
 import qualified Data.Avro.Schema.Schema    as Schema
-import qualified Data.ByteString            as ByteString
-import qualified Data.HashMap.Strict        as HashMap
-import qualified Data.Text                  as Text
-import qualified Data.Vector                as Vector
-import qualified Language.Haskell.TH.Lib as TH
-import qualified Language.Haskell.TH.Syntax as TH
 
 import           Language.Haskell.TH.Syntax (Lift (..))
 import           Instances.TH.Lift ()

--- a/src/Data/Avro/EitherN.hs
+++ b/src/Data/Avro/EitherN.hs
@@ -443,6 +443,7 @@ instance (FromAvro a, FromAvro b, FromAvro c) => FromAvro (Either3 a b c) where
   fromAvro (AV.Union _ 1 b) = E3_2 <$> fromAvro b
   fromAvro (AV.Union _ 2 c) = E3_3 <$> fromAvro c
   fromAvro (AV.Union _ n _) = Left ("Unable to decode Either3 from a position #" <> show n)
+  fromAvro n                = Left ("Unable to decode Either3 from value " <> AV.describeValue n)
 
 instance (FromAvro a, FromAvro b, FromAvro c, FromAvro d) => FromAvro (Either4 a b c d) where
   fromAvro (AV.Union _ 0 a) = E4_1 <$> fromAvro a
@@ -450,6 +451,7 @@ instance (FromAvro a, FromAvro b, FromAvro c, FromAvro d) => FromAvro (Either4 a
   fromAvro (AV.Union _ 2 c) = E4_3 <$> fromAvro c
   fromAvro (AV.Union _ 3 d) = E4_4 <$> fromAvro d
   fromAvro (AV.Union _ n _) = Left ("Unable to decode Either4 from a position #" <> show n)
+  fromAvro n                = Left ("Unable to decode Either4 from value " <> AV.describeValue n)
 
 instance (FromAvro a, FromAvro b, FromAvro c, FromAvro d, FromAvro e) => FromAvro (Either5 a b c d e) where
   fromAvro (AV.Union _ 0 a) = E5_1 <$> fromAvro a
@@ -458,6 +460,7 @@ instance (FromAvro a, FromAvro b, FromAvro c, FromAvro d, FromAvro e) => FromAvr
   fromAvro (AV.Union _ 3 d) = E5_4 <$> fromAvro d
   fromAvro (AV.Union _ 4 e) = E5_5 <$> fromAvro e
   fromAvro (AV.Union _ n _) = Left ("Unable to decode Either5 from a position #" <> show n)
+  fromAvro n                = Left ("Unable to decode Either5 from value " <> AV.describeValue n)
 
 instance (FromAvro a, FromAvro b, FromAvro c, FromAvro d, FromAvro e, FromAvro f) => FromAvro (Either6 a b c d e f) where
   fromAvro (AV.Union _ 0 a) = E6_1 <$> fromAvro a
@@ -467,6 +470,7 @@ instance (FromAvro a, FromAvro b, FromAvro c, FromAvro d, FromAvro e, FromAvro f
   fromAvro (AV.Union _ 4 e) = E6_5 <$> fromAvro e
   fromAvro (AV.Union _ 5 f) = E6_6 <$> fromAvro f
   fromAvro (AV.Union _ n _) = Left ("Unable to decode Either6 from a position #" <> show n)
+  fromAvro n                = Left ("Unable to decode Either6 from value " <> AV.describeValue n)
 
 instance (FromAvro a, FromAvro b, FromAvro c, FromAvro d, FromAvro e, FromAvro f, FromAvro g) => FromAvro (Either7 a b c d e f g) where
   fromAvro (AV.Union _ 0 a) = E7_1 <$> fromAvro a
@@ -477,6 +481,7 @@ instance (FromAvro a, FromAvro b, FromAvro c, FromAvro d, FromAvro e, FromAvro f
   fromAvro (AV.Union _ 5 f) = E7_6 <$> fromAvro f
   fromAvro (AV.Union _ 6 g) = E7_7 <$> fromAvro g
   fromAvro (AV.Union _ n _) = Left ("Unable to decode Either7 from a position #" <> show n)
+  fromAvro n                = Left ("Unable to decode Either7 from value " <> AV.describeValue n)
 
 instance (FromAvro a, FromAvro b, FromAvro c, FromAvro d, FromAvro e, FromAvro f, FromAvro g, FromAvro h) => FromAvro (Either8 a b c d e f g h) where
   fromAvro (AV.Union _ 0 a) = E8_1 <$> fromAvro a
@@ -488,6 +493,7 @@ instance (FromAvro a, FromAvro b, FromAvro c, FromAvro d, FromAvro e, FromAvro f
   fromAvro (AV.Union _ 6 g) = E8_7 <$> fromAvro g
   fromAvro (AV.Union _ 7 h) = E8_8 <$> fromAvro h
   fromAvro (AV.Union _ n _) = Left ("Unable to decode Either8 from a position #" <> show n)
+  fromAvro n                = Left ("Unable to decode Either8 from value " <> AV.describeValue n)
 
 instance (FromAvro a, FromAvro b, FromAvro c, FromAvro d, FromAvro e, FromAvro f, FromAvro g, FromAvro h, FromAvro i) => FromAvro (Either9 a b c d e f g h i) where
   fromAvro (AV.Union _ 0 a) = E9_1 <$> fromAvro a
@@ -500,6 +506,7 @@ instance (FromAvro a, FromAvro b, FromAvro c, FromAvro d, FromAvro e, FromAvro f
   fromAvro (AV.Union _ 7 h) = E9_8 <$> fromAvro h
   fromAvro (AV.Union _ 8 i) = E9_9 <$> fromAvro i
   fromAvro (AV.Union _ n _) = Left ("Unable to decode Either9 from a position #" <> show n)
+  fromAvro n                = Left ("Unable to decode Either9 from value " <> AV.describeValue n)
 
 instance (FromAvro a, FromAvro b, FromAvro c, FromAvro d, FromAvro e, FromAvro f, FromAvro g, FromAvro h, FromAvro i, FromAvro j) => FromAvro (Either10 a b c d e f g h i j) where
   fromAvro (AV.Union _ 0 a) = E10_1  <$> fromAvro a
@@ -513,6 +520,7 @@ instance (FromAvro a, FromAvro b, FromAvro c, FromAvro d, FromAvro e, FromAvro f
   fromAvro (AV.Union _ 8 i) = E10_9  <$> fromAvro i
   fromAvro (AV.Union _ 9 j) = E10_10 <$> fromAvro j
   fromAvro (AV.Union _ n _) = Left ("Unable to decode Either10 from a position #" <> show n)
+  fromAvro n                = Left ("Unable to decode Either10 from value " <> AV.describeValue n)
 
 putIndexedValue :: ToAvro a => Int -> V.Vector Schema -> a -> Builder
 putIndexedValue i opts x = putI i <> toAvro (V.unsafeIndex opts i) x

--- a/src/Data/Avro/Encoding/FromAvro.hs
+++ b/src/Data/Avro/Encoding/FromAvro.hs
@@ -8,6 +8,8 @@ module Data.Avro.Encoding.FromAvro
   -- ** For internal use
 , Value(..)
 , getValue
+
+, describeValue
 )
 where
 

--- a/src/Data/Avro/Encoding/FromAvro.hs
+++ b/src/Data/Avro/Encoding/FromAvro.hs
@@ -16,28 +16,21 @@ where
 import           Control.DeepSeq             (NFData)
 import           Control.Monad               (forM, replicateM)
 import           Control.Monad.Identity      (Identity (..))
-import           Control.Monad.ST            (ST)
-import qualified Data.Aeson                  as A
 import qualified Data.Avro.Internal.Get      as Get
 import           Data.Avro.Internal.Time
 import           Data.Avro.Schema.Decimal    as D
 import           Data.Avro.Schema.ReadSchema (ReadSchema)
 import qualified Data.Avro.Schema.ReadSchema as ReadSchema
 import qualified Data.Avro.Schema.Schema     as Schema
-import           Data.Binary.Get             (Get, getByteString, runGetOrFail)
-import qualified Data.ByteString             as B
+import           Data.Binary.Get             (Get, getByteString)
 import qualified Data.ByteString             as BS
 import qualified Data.ByteString.Lazy        as BL
-import qualified Data.Char                   as Char
 import           Data.Foldable               (traverse_)
 import           Data.HashMap.Strict         (HashMap)
 import qualified Data.HashMap.Strict         as HashMap
 import           Data.Int
-import           Data.List.NonEmpty          (NonEmpty)
 import qualified Data.Map                    as Map
 import           Data.Text                   (Text)
-import qualified Data.Text                   as T
-import qualified Data.Text                   as Text
 import qualified Data.Text.Encoding          as Text
 import qualified Data.Time                   as Time
 import qualified Data.UUID                   as UUID
@@ -78,7 +71,7 @@ data Value
 describeValue :: Value -> String
 describeValue = \case
   Null         -> "Null"
-  Boolean b    -> "Boolean"
+  Boolean _    -> "Boolean"
   Int s _      -> "Int (" <> show s <> ")"
   Long s _     -> "Long (" <> show s <> ")"
   Float s _    -> "Float (" <> show s <> ")"
@@ -311,17 +304,18 @@ getField env sch = case sch of
 getKVBlocks :: HashMap Schema.TypeName ReadSchema -> ReadSchema -> Get [[(Text, Value)]]
 getKVBlocks env t = do
   blockLength <- abs <$> Get.getLong
-  if blockLength == 0
-  then return []
-  else do vs <- replicateM (fromIntegral blockLength) ((,) <$> Get.getString <*> getField env t)
-          (vs:) <$> getKVBlocks env t
+  if blockLength == 0 then
+    return []
+  else do
+    vs <- replicateM (fromIntegral blockLength) ((,) <$> Get.getString <*> getField env t)
+    (vs:) <$> getKVBlocks env t
 {-# INLINE getKVBlocks #-}
 
 getBlocksOf :: HashMap Schema.TypeName ReadSchema -> ReadSchema -> Get [[Value]]
 getBlocksOf env t = do
   blockLength <- abs <$> Get.getLong
-  if blockLength == 0
-  then return []
+  if blockLength == 0 then
+    return []
   else do
     vs <- replicateM (fromIntegral blockLength) (getField env t)
     (vs:) <$> getBlocksOf env t
@@ -331,7 +325,7 @@ getRecord env fs = do
   moos <- fmap concat . forM fs $ \f ->
     case ReadSchema.fldStatus f of
       ReadSchema.Ignored       -> [] <$ getField env (ReadSchema.fldType f)
-      ReadSchema.AsIs i        -> (\f -> [(i,f)]) <$> getField env (ReadSchema.fldType f)
+      ReadSchema.AsIs i        -> (\fld -> [(i,fld)]) <$> getField env (ReadSchema.fldType f)
       ReadSchema.Defaulted i v -> pure [(i, convertValue v)] --undefined
 
   return $ V.create $ do

--- a/src/Data/Avro/Encoding/ToAvro.hs
+++ b/src/Data/Avro/Encoding/ToAvro.hs
@@ -7,8 +7,7 @@
 {-# LANGUAGE TypeApplications          #-}
 {-# LANGUAGE TypeFamilies              #-}
 
-module Data.Avro.Encoding.ToAvro
-where
+module Data.Avro.Encoding.ToAvro where
 
 import           Control.Monad.Identity       (Identity (..))
 import qualified Data.Array                   as Ar
@@ -29,13 +28,11 @@ import           Data.List                    as DL
 import qualified Data.Map.Strict              as Map
 import           Data.Maybe                   (fromJust)
 import           Data.Text                    (Text)
-import qualified Data.Text                    as T
 import qualified Data.Text.Encoding           as T
 #if MIN_VERSION_text(2,0,0)
 import qualified Data.Text.Foreign            as T
 #endif
 import qualified Data.Text.Lazy               as TL
-import qualified Data.Text.Lazy.Encoding      as TL
 import qualified Data.Time                    as Time
 import qualified Data.UUID                    as UUID
 import qualified Data.Vector                  as V
@@ -52,7 +49,7 @@ newtype Encoder = Encoder { runEncoder :: Schema -> Builder }
 
 record :: Schema -> [(Text, Encoder)] -> Builder
 record (S.Record _ _ _ fs) vs =
-  foldMap (mapField provided) fs
+    foldMap (mapField provided) fs
   where
     provided :: HashMap Text Encoder
     provided = HashMap.fromList vs
@@ -65,6 +62,8 @@ record (S.Record _ _ _ fs) vs =
     mapField :: HashMap Text Encoder -> S.Field -> Builder
     mapField env fld =
       maybe (failField fld) (flip runEncoder (S.fldType fld)) (HashMap.lookup (S.fldName fld) env)
+record _ _ =
+  error "Error in Schema passed to record. It was not of type Record."
 
 -- | Describes how to encode Haskell data types into Avro bytes
 class ToAvro a where
@@ -251,7 +250,7 @@ instance ToAvro a => ToAvro (Maybe a) where
   toAvro s _ = error ("Unable to encode Maybe as " <> show s)
 
 instance (ToAvro a) => ToAvro (Identity a) where
-  toAvro (S.Union opts) e@(Identity a) =
+  toAvro (S.Union opts) (Identity a) =
     if V.length opts == 1
       then putI 0 <> toAvro (V.unsafeIndex opts 0) a
       else error ("Unable to encode Identity as a single-value union: " <> show opts)

--- a/src/Data/Avro/HasAvroSchema.hs
+++ b/src/Data/Avro/HasAvroSchema.hs
@@ -8,9 +8,8 @@ import           Control.Monad.Identity   (Identity)
 import qualified Data.Array               as Ar
 import           Data.Avro.Schema.Decimal as D
 import           Data.Avro.Schema.Schema  as S
-import qualified Data.ByteString          as B
-import           Data.ByteString.Lazy     (ByteString)
-import qualified Data.ByteString.Lazy     as BL
+import qualified Data.ByteString          as Strict
+import qualified Data.ByteString.Lazy     as Lazy
 import qualified Data.HashMap.Strict      as HashMap
 import           Data.Int
 import           Data.Ix                  (Ix)
@@ -81,10 +80,10 @@ instance HasAvroSchema Text.Text where
 instance HasAvroSchema TL.Text where
   schema = Tagged S.String'
 
-instance HasAvroSchema B.ByteString where
+instance HasAvroSchema Strict.ByteString where
   schema = Tagged S.Bytes'
 
-instance HasAvroSchema BL.ByteString where
+instance HasAvroSchema Lazy.ByteString where
   schema = Tagged S.Bytes'
 
 instance (KnownNat p, KnownNat s) => HasAvroSchema (D.Decimal p s) where

--- a/src/Data/Avro/Internal/Container.hs
+++ b/src/Data/Avro/Internal/Container.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE BangPatterns        #-}
 {-# LANGUAGE DeriveFunctor       #-}
-{-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE RecordWildCards     #-}
@@ -23,15 +22,12 @@ import qualified Data.Avro.Schema.Schema      as Schema
 import           Data.Binary.Get              (Get)
 import qualified Data.Binary.Get              as Get
 import           Data.ByteString              (ByteString)
-import qualified Data.ByteString              as B
 import           Data.ByteString.Builder      (Builder, lazyByteString, toLazyByteString)
 import qualified Data.ByteString.Lazy         as BL
 import qualified Data.ByteString.Lazy.Char8   as BLC
-import           Data.Either                  (isRight)
 import           Data.HashMap.Strict          (HashMap)
 import qualified Data.HashMap.Strict          as HashMap
 import           Data.Int                     (Int32, Int64)
-import           Data.List                    (foldl', unfoldr)
 import qualified Data.Map.Strict              as Map
 import           Data.Text                    (Text)
 import           System.Random.TF.Init        (initTFGen)
@@ -97,7 +93,7 @@ getContainerHeader = do
 decodeRawBlocks :: BL.ByteString -> Either String (Schema, [Either String (Int, BL.ByteString)])
 decodeRawBlocks bs =
   case Get.runGetOrFail getContainerHeader bs of
-    Left (bs', _, err) -> Left err
+    Left (_, _, err) -> Left err
     Right (bs', _, containerHeader@ContainerHeader {..}) ->
       let blocks = allBlocks containerHeader bs'
       in Right (containedSchema, blocks)

--- a/src/Data/Avro/Internal/Get.hs
+++ b/src/Data/Avro/Internal/Get.hs
@@ -11,24 +11,16 @@
 module Data.Avro.Internal.Get
 where
 
-import qualified Codec.Compression.Zlib     as Z
-import           Control.Monad              (replicateM, when)
+import           Control.Monad              (replicateM)
 import           Data.Binary.Get            (Get)
 import qualified Data.Binary.Get            as G
 import           Data.Binary.IEEE754        as IEEE
 import           Data.Bits
 import           Data.ByteString            (ByteString)
 import qualified Data.ByteString.Lazy       as BL
-import qualified Data.ByteString.Lazy.Char8 as BC
 import           Data.Int
-import qualified Data.Map                   as Map
-import           Data.Maybe
-import           Data.Monoid                ((<>))
-import qualified Data.Set                   as Set
 import           Data.Text                  (Text)
-import qualified Data.Text                  as Text
 import qualified Data.Text.Encoding         as Text
-import qualified Data.Vector                as V
 import           Prelude                    as P
 
 import Data.Avro.Internal.DecodeRaw

--- a/src/Data/Avro/Internal/Time.hs
+++ b/src/Data/Avro/Internal/Time.hs
@@ -3,10 +3,8 @@ module Data.Avro.Internal.Time where
 
 -- Utility functions to work with times
 
-import Data.Fixed            (Fixed (..))
 import Data.Maybe            (fromJust)
 import Data.Time
-import Data.Time.Clock
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 #if MIN_VERSION_time(1,9,0)
 import Data.Time.Format.Internal

--- a/src/Data/Avro/Schema/Deconflict.hs
+++ b/src/Data/Avro/Schema/Deconflict.hs
@@ -6,25 +6,16 @@ module Data.Avro.Schema.Deconflict
 import           Control.Applicative     ((<|>))
 import           Data.Avro.Schema.Schema as S
 import qualified Data.Foldable           as Foldable
-import           Data.HashMap.Strict     (HashMap)
-import qualified Data.HashMap.Strict     as HashMap
 import           Data.List               (find)
-import           Data.List.NonEmpty      (NonEmpty (..))
-import qualified Data.List.NonEmpty      as NE
-import qualified Data.Map                as M
 import           Data.Maybe              (isNothing)
-import           Data.Semigroup          ((<>))
 import qualified Data.Set                as Set
 import           Data.Text               (Text)
 import qualified Data.Text               as Text
-import qualified Data.Text.Encoding      as Text
 import           Data.Vector             (Vector)
 import qualified Data.Vector             as V
 
 import           Data.Avro.Schema.ReadSchema (FieldStatus (..), ReadField, ReadSchema)
 import qualified Data.Avro.Schema.ReadSchema as Read
-
-import Debug.Trace
 
 -- | @deconflict writer reader@ will produce a schema that can decode
 -- with the writer's schema into the form specified by the reader's schema.

--- a/src/Data/Avro/Schema/ReadSchema.hs
+++ b/src/Data/Avro/Schema/ReadSchema.hs
@@ -21,10 +21,8 @@ where
 import           Control.DeepSeq         (NFData)
 import           Data.Avro.Schema.Schema (LogicalTypeBytes, LogicalTypeFixed, LogicalTypeInt, LogicalTypeLong, LogicalTypeString, Order, TypeName)
 import qualified Data.Avro.Schema.Schema as S
-import           Data.HashMap.Strict     (HashMap)
 import qualified Data.HashMap.Strict     as HashMap
 import           Data.Text               (Text)
-import qualified Data.Text               as T
 import qualified Data.Vector             as V
 import           GHC.Generics            (Generic)
 


### PR DESCRIPTION
There were a few partial pattern matches and a lot
of other warnings regarding shadowing and redundant
imports.

This tidies up most of them.
