### PR TITLE
Fix Map decoding in presence of optional long byte-length marker

### DIFF
--- a/src/Data/Avro/Encoding/FromAvro.hs
+++ b/src/Data/Avro/Encoding/FromAvro.hs
@@ -306,7 +306,7 @@ getKVBlocks env t = do
   if lengthIndicator == 0 then
     return []
   else do
-    when (lengthIndicator < 0) $ void $ Get.getLong  -- number of bytes in block
+    when (lengthIndicator < 0) $ void Get.getLong  -- number of bytes in block
     let blockLength = abs lengthIndicator
     vs <- replicateM (fromIntegral blockLength) ((,) <$> Get.getString <*> getField env t)
     (vs:) <$> getKVBlocks env t
@@ -314,10 +314,12 @@ getKVBlocks env t = do
 
 getBlocksOf :: HashMap Schema.TypeName ReadSchema -> ReadSchema -> Get [[Value]]
 getBlocksOf env t = do
-  blockLength <- abs <$> Get.getLong
-  if blockLength == 0 then
+  lengthIndicator <- Get.getLong
+  if lengthIndicator == 0 then
     return []
   else do
+    when (lengthIndicator < 0) $ void Get.getLong  -- number of bytes in block
+    let blockLength = abs lengthIndicator
     vs <- replicateM (fromIntegral blockLength) (getField env t)
     (vs:) <$> getBlocksOf env t
 

--- a/src/Data/Avro/Encoding/FromAvro.hs
+++ b/src/Data/Avro/Encoding/FromAvro.hs
@@ -14,7 +14,7 @@ module Data.Avro.Encoding.FromAvro
 where
 
 import           Control.DeepSeq             (NFData)
-import           Control.Monad               (forM, replicateM)
+import           Control.Monad               (forM, replicateM, void, when)
 import           Control.Monad.Identity      (Identity (..))
 import qualified Data.Avro.Internal.Get      as Get
 import           Data.Avro.Internal.Time
@@ -195,7 +195,6 @@ instance FromAvro Time.LocalTime where
     Right $ millisToLocalTime (toInteger n)
   fromAvro x = Left ("Unable to decode LocalTime from: " <> show (describeValue x))
   {-# INLINE fromAvro #-}
-  
 
 instance FromAvro a => FromAvro [a] where
   fromAvro (Array vec) = mapM fromAvro $ V.toList vec
@@ -303,10 +302,12 @@ getField env sch = case sch of
 
 getKVBlocks :: HashMap Schema.TypeName ReadSchema -> ReadSchema -> Get [[(Text, Value)]]
 getKVBlocks env t = do
-  blockLength <- abs <$> Get.getLong
-  if blockLength == 0 then
+  lengthIndicator <- Get.getLong
+  if lengthIndicator == 0 then
     return []
   else do
+    when (lengthIndicator < 0) $ void $ Get.getLong  -- number of bytes in block
+    let blockLength = abs lengthIndicator
     vs <- replicateM (fromIntegral blockLength) ((,) <$> Get.getString <*> getField env t)
     (vs:) <$> getKVBlocks env t
 {-# INLINE getKVBlocks #-}


### PR DESCRIPTION
I encountered a problem where messages that have an Avro `Map` produced by certain other Avro libraries were not decoding, and I noticed that we are not decoding maps properly in the presence of this optional byte-length indicator.

> If a block’s count is negative, its absolute value is used, and the count is followed immediately by a long block size indicating the number of bytes in the block. This block size permits fast skipping through data, e.g., when projecting a record to a subset of its fields.

- https://avro.apache.org/docs/1.11.1/specification/#complex-types-1