### PR TITLE
Relax doctest constraint.

### DIFF
--- a/avro.cabal
+++ b/avro.cabal
@@ -57,7 +57,7 @@ common containers               { build-depends: containers                     
 common data-binary-ieee754      { build-depends: data-binary-ieee754                                                }
 common deepseq                  { build-depends: deepseq                                                            }
 common directory                { build-depends: directory                                                          }
-common doctest                  { build-depends: doctest                  >= 0.16.2     && < 0.21                   }
+common doctest                  { build-depends: doctest                  >= 0.16.2     && < 0.23                   }
 common doctest-discover         { build-depends: doctest-discover         >= 0.2        && < 0.3                    }
 common extra                    { build-depends: extra                                                              }
 common fail                     { build-depends: fail                                                               }


### PR DESCRIPTION
Stackage and nixpkgs are now on doctest 0.22, so the tests don't build. Simply relaxing the constraint seems to solve the problem.